### PR TITLE
Iot 569 : Added support for modify device config on cloud

### DIFF
--- a/clearblade/cloud/iot_v1/client.py
+++ b/clearblade/cloud/iot_v1/client.py
@@ -1,4 +1,4 @@
-from devices import SendCommandToDeviceRequest, CreateDeviceRequest, ClearBladeDeviceManager
+from devices import *
 
 class DeviceManagerClient():
 
@@ -10,6 +10,16 @@ class DeviceManagerClient():
         cb_device_manager = ClearBladeDeviceManager()
         return cb_device_manager.create(request=request)
 
+    def modify_cloud_to_device_config(self, request: ModifyCloudToDeviceConfigRequest,
+                                      name: str = None,
+                                      version_to_update = -1,
+                                      binary_data:bytes = None):
+
+        cb_device_manager = ClearBladeDeviceManager()
+        return cb_device_manager.modify_cloud_device_config(request=request,
+                                                            name=name,
+                                                            version_to_update=version_to_update,
+                                                            binary_data=binary_data)
 
 
 class DeviceManagerAsyncClient():
@@ -21,3 +31,14 @@ class DeviceManagerAsyncClient():
     async def create_device(self, request):
         cb_device_manager = ClearBladeDeviceManager()
         return await cb_device_manager.create_async(request)
+
+    async def modify_cloud_to_device_config(self, request: ModifyCloudToDeviceConfigRequest,
+                                            name: str = None,
+                                            version_to_update = -1,
+                                            binary_data:bytes = None):
+
+        cb_device_manager = ClearBladeDeviceManager()
+        return await cb_device_manager.modify_cloud_device_config_async(request=request,
+                                                            name=name,
+                                                            version_to_update=version_to_update,
+                                                            binary_data=binary_data)

--- a/clearblade/cloud/iot_v1/client.py
+++ b/clearblade/cloud/iot_v1/client.py
@@ -21,6 +21,15 @@ class DeviceManagerClient():
                                                             version_to_update=version_to_update,
                                                             binary_data=binary_data)
 
+    def delete_device(self, request):
+        cb_device_manager = ClearBladeDeviceManager()
+        return cb_device_manager.delete(request=request)
+
+    def get_device(self, request):
+        cb_device_manager = ClearBladeDeviceManager()
+        return cb_device_manager.get(request=request)
+        
+
 
 class DeviceManagerAsyncClient():
 
@@ -42,3 +51,11 @@ class DeviceManagerAsyncClient():
                                                             name=name,
                                                             version_to_update=version_to_update,
                                                             binary_data=binary_data)
+
+    async def delete_device(self, request):
+        cb_device_manager = ClearBladeDeviceManager()
+        return await cb_device_manager.delete_async(request=request)
+
+    async def get_device(self, request):
+        cb_device_manager = ClearBladeDeviceManager()
+        return await cb_device_manager.get_async(request=request)

--- a/clearblade/cloud/iot_v1/developer_tests.py
+++ b/clearblade/cloud/iot_v1/developer_tests.py
@@ -1,5 +1,5 @@
 from client import DeviceManagerClient, DeviceManagerAsyncClient
-from devices import SendCommandToDeviceRequest, CreateDeviceRequest, Device
+from devices import SendCommandToDeviceRequest, CreateDeviceRequest, Device, ModifyCloudToDeviceConfigRequest
 import asyncio
 
 def test_send_command():
@@ -28,8 +28,15 @@ async def test_create_device_async():
     response = await async_client.create_device(request=request)
     print(response)
 
+def test_modify_cloud_to_device_config():
+    client =  DeviceManagerClient()
+    modify_cloud_config_device_request = ModifyCloudToDeviceConfigRequest(name='python_1', binary_data=b'QUJD', version_to_update=1)
+    response = client.modify_cloud_to_device_config(request=modify_cloud_config_device_request)
+    print(response.text)
+
 if __name__ ==  '__main__':
-    test_send_command()
-    asyncio.run(test_send_command_async())
-    test_create_device()
-    asyncio.run(test_create_device_async())
+    #test_send_command()
+    #asyncio.run(test_send_command_async())
+    #test_create_device()
+    #asyncio.run(test_create_device_async())
+    test_modify_cloud_to_device_config()

--- a/clearblade/cloud/iot_v1/developer_tests.py
+++ b/clearblade/cloud/iot_v1/developer_tests.py
@@ -1,5 +1,5 @@
 from client import DeviceManagerClient, DeviceManagerAsyncClient
-from devices import SendCommandToDeviceRequest, CreateDeviceRequest, Device, ModifyCloudToDeviceConfigRequest
+from devices import SendCommandToDeviceRequest, CreateDeviceRequest, Device, ModifyCloudToDeviceConfigRequest, DeleteDeviceRequest, GetDeviceRequest
 import asyncio
 
 def test_send_command():
@@ -16,7 +16,7 @@ async def test_send_command_async():
 
 def test_create_device():
     client = DeviceManagerClient()
-    device = Device(id="Python_10", name="Python_10")
+    device = Device(id="Python_101", name="Python_101")
     request = CreateDeviceRequest(device=device)
     response = client.create_device(request=request)
     print(response)
@@ -34,9 +34,37 @@ def test_modify_cloud_to_device_config():
     response = client.modify_cloud_to_device_config(request=modify_cloud_config_device_request)
     print(response.text)
 
+def test_delete_device():
+    client =  DeviceManagerClient()
+    delete_device_request = DeleteDeviceRequest(name='Python_12')
+    response = client.delete_device(request=delete_device_request)
+    print(response)
+
+async def test_delete_device_async():
+    async_client =  DeviceManagerAsyncClient()
+    delete_device_request = DeleteDeviceRequest(name='Python_10')
+    response = await async_client.delete_device(request=delete_device_request)
+    print(response)
+
+def test_get_device():
+    client =  DeviceManagerClient()
+    get_device_request = GetDeviceRequest(name='Python_101')
+    response = client.get_device(request=get_device_request)
+    print(response)
+
+async def test_get_device_async():
+    async_client =  DeviceManagerAsyncClient()
+    get_device_request = GetDeviceRequest(name='Python_10')
+    response = await async_client.get_device(request=get_device_request)
+    print(response)
+
 if __name__ ==  '__main__':
     #test_send_command()
     #asyncio.run(test_send_command_async())
     #test_create_device()
     #asyncio.run(test_create_device_async())
-    test_modify_cloud_to_device_config()
+    #test_modify_cloud_to_device_config()
+    #test_delete_device()
+    #asyncio.run(test_delete_device_async())
+    test_get_device()
+    #asyncio.run(test_get_device_async())

--- a/clearblade/cloud/iot_v1/devices.py
+++ b/clearblade/cloud/iot_v1/devices.py
@@ -4,14 +4,14 @@ class Device():
     """
     Data class for Clearblade Device
     """
-    #TODO: find a better way to construct the Device object. I dont like so much parameter in a constructor    
-    def __init__(self, id: str = None, name: str = None, num_id: str=None, 
-                 credentials: list=[], last_heartbeat_time: str = None, last_event_time: str = None, 
-                 last_state_time: str = None, last_config_ack_time: str = None, 
+    #TODO: find a better way to construct the Device object. I dont like so much parameter in a constructor
+    def __init__(self, id: str = None, name: str = None, num_id: str=None,
+                 credentials: list=[], last_heartbeat_time: str = None, last_event_time: str = None,
+                 last_state_time: str = None, last_config_ack_time: str = None,
                  last_config_send_time: str = None, blocked: bool = False,
                  last_error_time: str = None, last_error_status_code: dict = {"code":None, "message":""},
-                 config: dict = {"cloudUpdateTime":None, "version":""} , 
-                 state: dict = {"updateTime":None, "binaryData":None}, 
+                 config: dict = {"cloudUpdateTime":None, "version":""} ,
+                 state: dict = {"updateTime":None, "binaryData":None},
                  log_level: str = "NONE", meta_data: dict = {}, gateway_config : dict = {}  ) -> None:
 
         self._id = id
@@ -30,7 +30,7 @@ class Device():
         self._state =  state
         self._log_level = log_level
         self._meta_data = meta_data
-        self._gateway_config = gateway_config      
+        self._gateway_config = gateway_config
 
     @staticmethod
     def from_json(json):
@@ -38,7 +38,7 @@ class Device():
                       credentials= json['credentials'], last_heartbeat_time= json['lastHeartbeatTime'],
                       last_event_time= json['lastEventTime'], last_state_time= json['lastStateTime'],
                       last_config_ack_time= json['lastConfigAckTime'], last_config_send_time= json['lastConfigSendTime'],
-                      blocked= json['blocked'], last_error_time= json['lastErrorTime'], 
+                      blocked= json['blocked'], last_error_time= json['lastErrorTime'],
                       last_error_status_code= json['lastErrorStatus'], config= json['config'],
                       state= json['state'], log_level= json['logLevel'], meta_data= json['metadata'],
                       gateway_config= json['gatewayConfig'])
@@ -101,7 +101,7 @@ class SendCommandToDeviceRequest(Request):
     def __init__(self, name: str = None,
                 binary_data: bytes = None,
                 subfolder: str = None) -> None:
-        super().__init__(name)       
+        super().__init__(name)
         self._binary_data = binary_data
         self._subfolder = subfolder
 
@@ -123,6 +123,21 @@ class CreateDeviceRequest(Request):
     def device(self):
         return self._device
 
+class ModifyCloudToDeviceConfigRequest(Request):
+    def __init__(self, name:str = None ,
+                 version_to_update: int = -1,
+                 binary_data: bytes = None) -> None:
+        super().__init__(name)
+        self._version_to_update = version_to_update
+        self._binary_data = binary_data
+
+    @property
+    def version_to_update(self):
+        return self._version_to_update
+
+    @property
+    def binary_data(self):
+        return self._binary_data
 
 class ClearBladeDeviceManager():
 
@@ -131,7 +146,7 @@ class ClearBladeDeviceManager():
                                   name: str = None,
                                   binary_data: bytes = None,
                                   subfolder: str = None):
-        has_flattened_params = any([name, binary_data, subfolder])
+        has_flattened_params = any([name, binary_data])
         if request is not None and has_flattened_params:
             raise ValueError(
                 "If the `request` argument is set, then none of "
@@ -146,7 +161,7 @@ class ClearBladeDeviceManager():
         return params,body
 
     def _create_device_body(self, device: Device) :
-        return {'id':device.name, 'name':device.name, 
+        return {'id':device.name, 'name':device.name,
                 'credentials':device.credentials, 'lastErrorStatus':device.last_error_status,
                 'config':device.config, 'state':device.state,
                 'loglevel':device.log_level, 'metadata':device.meta_data,
@@ -154,6 +169,25 @@ class ClearBladeDeviceManager():
 
     def _create_device_from_response(self, json_response) -> Device :
         return Device.from_json(json=json_response)
+
+    def _prepare_modify_cloud_config_device(self,
+                                            request: ModifyCloudToDeviceConfigRequest,
+                                            name, binary_data, version_to_update):
+
+        has_flattened_params = any([name, binary_data])
+        if request is not None and has_flattened_params:
+            raise ValueError(
+                "If the `request` argument is set, then none of "
+                "the individual field arguments should be set."
+            )
+
+        if request is None:
+            request = ModifyCloudToDeviceConfigRequest(name=name,version_to_update=version_to_update, binary_data=binary_data)
+
+        params = {'name': request.name, 'method': 'modifyCloudToDeviceConfig'}
+        body = {'binaryData': request.binary_data.decode("utf-8"), 'versionToUpdate':request.version_to_update}
+
+        return params, body
 
     def send_command(self,
                     request: SendCommandToDeviceRequest,
@@ -164,7 +198,7 @@ class ClearBladeDeviceManager():
         params, body = self._prepare_for_send_command(request, name, binary_data, subfolder)
         sync_client = SyncClient()
         return sync_client.post(request_params=params, request_body=body)
-    
+
     async def send_command_async(self,
                                  request: SendCommandToDeviceRequest = None,
                                  name: str = None,
@@ -175,7 +209,7 @@ class ClearBladeDeviceManager():
         return await async_client.post(request_params=params, request_body=body)
 
     def create(self, request: CreateDeviceRequest,
-                     parent: str = None, 
+                     parent: str = None,
                      device: Device = None) -> Device:
         sync_client = SyncClient()
         body = self._create_device_body(request.device)
@@ -188,16 +222,38 @@ class ClearBladeDeviceManager():
         return None
 
     async def create_async(self, request: CreateDeviceRequest,
-                           parent: str = None, 
+                           parent: str = None,
                            device: Device = None) -> Device:
-        
+
         async_client = AsyncClient()
         body = self._create_device_body(request.device)
         response = await async_client.post(request_body=body)
-        
+
         if response.status_code is 200:
             return self._create_device_from_response(response.json())
         return None
+
+    def modify_cloud_device_config(self,
+                                   request: ModifyCloudToDeviceConfigRequest,
+                                   name:str = None,
+                                   version_to_update : int = None,
+                                   binary_data: bytes = None):
+        sync_client = SyncClient()
+        params, body = self._prepare_modify_cloud_config_device(request=request, name=name,
+                                                                binary_data=binary_data, version_to_update=version_to_update)
+        response = sync_client.post(request_params=params, request_body=body)
+        return response
+
+    async def modify_cloud_device_config_async(self,
+                                        request: ModifyCloudToDeviceConfigRequest,
+                                        name:str = None,
+                                        version_to_update : int = None,
+                                        binary_data: bytes = None):
+        params, body = self._prepare_modify_cloud_config_device(request=request, name=name,
+                                                                binary_data=binary_data, version_to_update=version_to_update)
+        async_client = AsyncClient()
+        response = await async_client.post(request_params=params, request_body=body)
+        return response
 
     def list(self):
         pass

--- a/clearblade/cloud/iot_v1/devices.py
+++ b/clearblade/cloud/iot_v1/devices.py
@@ -168,6 +168,14 @@ class DeviceConfig(Request):
         return DeviceConfig(version=json['version'], cloud_ack_time=json['cloudUpdateTime'],
                             device_ack_time=json['deviceAckTime'], binary_data=json['binaryData'])
 
+class DeleteDeviceRequest(Request):
+    def __init__(self, name: str = None) -> None:
+        super().__init__(name)
+
+class GetDeviceRequest(Request):
+    def __init__(self, name: str = None) -> None:
+        super().__init__(name)
+
 class ClearBladeDeviceManager():
 
     def _prepare_for_send_command(self,
@@ -296,8 +304,38 @@ class ClearBladeDeviceManager():
     def list(self):
         pass
 
-    def get(self):
-        pass
+    def get(self,
+            request: GetDeviceRequest) -> Device:
+        sync_client = SyncClient()
+        params = {'name':request.name}
+        response = sync_client.get(request_params=params)
+        
+        if response.status_code is 200:
+            return self._create_device_from_response(response.json())
+        return None
 
-    def delete(self):
-        pass
+    async def get_async(self,
+            request: GetDeviceRequest):
+        async_client = AsyncClient()
+        params = {'name':request.name}
+        response = await async_client.get(request_params=params)
+
+        if response.status_code is 200:
+            return self._create_device_from_response(response.json())
+        return None
+
+    def delete(self,
+               request: DeleteDeviceRequest):
+        sync_client = SyncClient()
+        params = {'name':request.name}
+        response = sync_client.delete(request_params=params)
+
+        return response
+
+    async def delete_async(self,
+               request: DeleteDeviceRequest):
+        async_client = AsyncClient()
+        params = {'name':request.name}
+        response = await async_client.delete(request_params=params)
+
+        return response

--- a/clearblade/cloud/iot_v1/http_client.py
+++ b/clearblade/cloud/iot_v1/http_client.py
@@ -37,8 +37,9 @@ class HttpClient():
     def _process_request_body(self, request_body = {}):
         return json.dumps(request_body)
 
-    def get(self, request_params, request_body):
-        pass
+    def get(self, request_params):
+        self._post_url = self._cb_api_url+ self._process_request_params(request_params=request_params)
+        self._request_headers = self._headers()        
 
     def post(self, request_params = {}, request_body = {}):
         self._post_url = self._cb_api_url+ self._process_request_params(request_params=request_params)
@@ -46,8 +47,9 @@ class HttpClient():
         self._post_body = self._process_request_body(request_body=request_body)
         print("post_url = {}\nheaders = {}\nbody= {}\n".format(self._post_url,self._request_headers,self._post_body))
 
-    def delete(self, request_params, request_body):
-        pass
+    def delete(self, request_params):
+        self._post_url = self._cb_api_url+ self._process_request_params(request_params=request_params)
+        self._request_headers = self._headers()
 
 class SyncClient(HttpClient):
 
@@ -58,7 +60,20 @@ class SyncClient(HttpClient):
         response = httpx_sync_client.request("POST", url=self._post_url,
                                             headers=self._request_headers, data=self._post_body)
         return response
+    
+    def delete(self, request_params):
+        super().delete(request_params=request_params)
+        httpx_sync_client = httpx.Client()
+        response = httpx_sync_client.request("DELETE", url=self._post_url,
+                                            headers=self._request_headers)
+        return response
 
+    def get(self, request_params = {}):
+        super().get(request_params=request_params)
+        httpx_sync_client = httpx.Client()
+        response = httpx_sync_client.request("GET", url=self._post_url,
+                                            headers=self._request_headers)
+        return response
 
 class AsyncClient(HttpClient):
 
@@ -67,5 +82,13 @@ class AsyncClient(HttpClient):
         httpx_async_client= httpx.AsyncClient()
         response = await httpx_async_client.request("POST", url=self._post_url,
                                                     headers=self._request_headers, data=self._post_body)
+        await httpx_async_client.aclose()
+        return response
+
+    async def delete(self, request_params):
+        super().delete(request_params=request_params)
+        httpx_async_client= httpx.AsyncClient()
+        response = await httpx_async_client.request("DELETE", url=self._post_url,
+                                            headers=self._request_headers)
         await httpx_async_client.aclose()
         return response

--- a/samples/clearblade/create_device_async.py
+++ b/samples/clearblade/create_device_async.py
@@ -1,9 +1,10 @@
 from clearblade.cloud import iot_v1
 
-async def sample_send_command_to_device():
+async def sample_create_device_async():
     client = iot_v1.DeviceManagerAsyncClient()
 
-    device = iot_v1.Device(id="Python_12", name="Python_12")
+    device = iot_v1.Device(id="Python_11", name="Python_11")
     request = iot_v1.CreateDeviceRequest(device=device)
 
     response = await client.create_device(request)
+

--- a/samples/clearblade/create_device_sync.py
+++ b/samples/clearblade/create_device_sync.py
@@ -1,9 +1,11 @@
 from clearblade.cloud import iot_v1
 
-def sample_send_command_to_device():
+def sample_create_device():
     client = iot_v1.DeviceManagerClient()
 
-    device = iot_v1.Device(id="Python_12", name="Python_12")
+    device = iot_v1.Device(id="Python_11", name="Python_11")
     request = iot_v1.CreateDeviceRequest(device=device)
 
     response = client.create_device(request)
+
+sample_create_device()

--- a/samples/clearblade/delete_device_async.py
+++ b/samples/clearblade/delete_device_async.py
@@ -1,0 +1,10 @@
+from clearblade.cloud import iot_v1
+
+async def sample_device_delete_async():
+    client = iot_v1.DeviceManagerAsyncClient()
+
+    request = iot_v1.DeleteDeviceRequest(name='Python_12')
+
+    response = await client.delete_device(request)
+
+sample_device_delete_async()

--- a/samples/clearblade/delete_device_sync.py
+++ b/samples/clearblade/delete_device_sync.py
@@ -1,0 +1,10 @@
+from clearblade.cloud import iot_v1
+
+async def sample_device_delete():
+    client = iot_v1.DeviceManagerClient()
+
+    request = iot_v1.DeleteDeviceRequest(name='Python_12')
+
+    response = await client.delete_device(request)
+
+sample_device_delete()

--- a/samples/clearblade/send_command_to_device.py
+++ b/samples/clearblade/send_command_to_device.py
@@ -5,5 +5,3 @@ def sample_send_command_to_device():
     request = iot_v1.SendCommandToDeviceRequest(name='python_1', binary_data="QUJD")
     response = client.send_command_to_device(request)
     print(response)
-    
-sample_send_command_to_device()


### PR DESCRIPTION
This PR adds support for Modify Device Config on Cloud. 

1. Adds request and device config class required for the api request. 
2. Adds sync and async method to modify device config to cloud. 
3. Adds  required developer tests. 
4. Adds required sample tests