### PR TITLE
Removed requirement of region and registry environment variables

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-Python Client for Google Cloud Internet of Things (IoT) Core API
+Python Client for ClearBlade Internet of Things (IoT) Core API
 ================================================================
 
 Quick Start
@@ -6,9 +6,13 @@ Quick Start
 
 In order to use this library, you first need to go through the following steps:
 
-1. set an environment variable CLEARBLADE_CONFIGURATION which should point to your service account json file.
-2. set an environment variable CLEARBLADE_REGISTRY which should be the name of registry we want to work upon.
-3. set an environment variable CLEARBLADE_REGION which should point to the region.
+1. Install pip package 
+```
+pip install clearblade-cloud-iot
+```
+
+2. Set an environment variable CLEARBLADE_CONFIGURATION which should point to your clearblade service account json file.
+
 
 Installation
 ~~~~~~~~~~~~

--- a/clearblade/cloud/iot_v1/client.py
+++ b/clearblade/cloud/iot_v1/client.py
@@ -3,7 +3,30 @@ from .registry import *
 from .device_types import *
 from .registry_types import *
 
-class DeviceManagerClient():
+class Client():
+    def device_path(
+        project: str,
+        location: str,
+        registry: str,
+        device: str
+        ) -> str:
+        cb_device_manager = ClearBladeDeviceManager()
+        return cb_device_manager.device_path(project=project, 
+                                             location=location, 
+                                             registry=registry, 
+                                             device=device)
+    
+    def registry_path(
+        project: str,
+        location: str,
+        registry: str
+        ) -> str:
+        cb_device_manager = ClearBladeDeviceManager()
+        return cb_device_manager.registry_path(project=project, 
+                                               location=location, 
+                                               registry=registry)
+
+class DeviceManagerClient(Client):
 
     def send_command_to_device(self,request:SendCommandToDeviceRequest):
         cb_device_manager = ClearBladeDeviceManager()
@@ -76,7 +99,7 @@ class DeviceManagerClient():
         cb_registry_manager = ClearBladeRegistryManager()
         return cb_registry_manager.patch(request=request)
 
-class DeviceManagerAsyncClient():
+class DeviceManagerAsyncClient(Client):
 
     async def send_command_to_device(self, request:SendCommandToDeviceRequest):
         cb_device_manager = ClearBladeDeviceManager()

--- a/clearblade/cloud/iot_v1/client.py
+++ b/clearblade/cloud/iot_v1/client.py
@@ -1,10 +1,11 @@
+from .device_types import *
 from .devices import *
 from .registry import *
-from .device_types import *
 from .registry_types import *
 
 class Client():
     def device_path(
+        self,
         project: str,
         location: str,
         registry: str,
@@ -17,6 +18,7 @@ class Client():
                                              device=device)
     
     def registry_path(
+        self,
         project: str,
         location: str,
         registry: str

--- a/clearblade/cloud/iot_v1/config_manager.py
+++ b/clearblade/cloud/iot_v1/config_manager.py
@@ -7,8 +7,6 @@ class ClearBladeConfigManager:
     def __init__(self) -> None:
         self._admin_config:ClearBladeConfig = None
         self._regional_config:ClearBladeConfig = None
-        self._region_name:str = os.environ.get("CLEARBLADE_REGION")
-        self._registry_name:str = os.environ.get("CLEARBLADE_REGISTRY")
 
     def _set_admin_clearblade_config(self):
         if self._admin_config:
@@ -45,10 +43,13 @@ class ClearBladeConfigManager:
         self._set_admin_clearblade_config()
 
         if not region:
-            region = self._region_name
+            region = self.region_name
 
         if not registry:
             registry = self.registry_name
+
+        if not region or not registry:
+            raise Exception("Either location or registry name is not provided")
 
         sync_client = SyncClient(clearblade_config=self._admin_config)
         request_body = {'region':region,'registry':registry, 'project':self._admin_config.project}
@@ -116,3 +117,11 @@ class ClearBladeConfigManager:
     @property
     def region_name(self):
         return self._region_name
+
+    @registry_name.setter
+    def registry_name(self, registry_name):
+        self._registry_name = registry_name
+
+    @region_name.setter
+    def region_name(self, region_name):
+        self._region_name = region_name

--- a/clearblade/cloud/iot_v1/device_types.py
+++ b/clearblade/cloud/iot_v1/device_types.py
@@ -1,5 +1,7 @@
-from .utils import get_value
 from typing import List
+
+from .utils import get_value
+
 
 class Device():
     """
@@ -109,12 +111,12 @@ class DeviceState():
                            binary_data=get_value(response_json, 'binaryData'))
 
 class Request():
-    def __init__(self, name) -> None:
-        self._name = name
+    def __init__(self, parent) -> None:
+        self._parent = parent
 
     @property
-    def name(self):
-        return self._name
+    def parent(self):
+        return self._parent
 
 class SendCommandToDeviceRequest(Request):
     def __init__(self, name: str = None,
@@ -133,9 +135,9 @@ class SendCommandToDeviceRequest(Request):
         return self._subfolder
 
 class CreateDeviceRequest(Request):
-    def __init__(self, name: str = None,
+    def __init__(self, parent: str = None,
                        device: Device = None) -> None:
-        super().__init__(name)
+        super().__init__(parent)
         self._device = device
 
     @property
@@ -236,13 +238,13 @@ class UnbindDeviceFromGatewayRequest(BindUnBindGatewayDeviceRequest):
 
 class ListDeviceStatesRequest(Request):
     def __init__(self, name: str = None,
-                num_states: int = None) -> None:
+                numStates: int = None) -> None:
         super().__init__(name)
-        self._num_states = num_states
+        self._numStates = numStates
 
     @property
-    def num_states(self):
-        return self._num_states
+    def numStates(self):
+        return self._numStates
 
 class ListDeviceStatesResponse():
     def __init__(self, device_states:List[DeviceState] = []) -> None:
@@ -293,40 +295,27 @@ class ListDeviceConfigVersionsResponse():
         return ListDeviceConfigVersionsResponse(device_configs=deviceConfigs)
 
 class UpdateDeviceRequest(Request):
-    def __init__(self, id: str = None, name: str = None, numId: str=None,
-                 credentials: list=None, blocked: bool = None,
-                 logLevel: str = None, metadata: dict = None, gatewayConfig : dict = None,
-                 updateMask: str = None) -> None:
-        self._id = id
-        self._name = name
-        self._num_id = numId
-        self._credentials = credentials
-        self._blocked = blocked
-        self._log_level = logLevel
-        self._meta_data = metadata
-        self._gateway_config = gatewayConfig
+    def __init__(self, parent: str = None, device: Device = None, updateMask: str = None) -> None:
+        self._parent = parent
+        self._device = device
         self._update_mask = updateMask
 
     def _prepare_params_body_for_update(self):
-        params = {'name': self._name}
+        params = {'name': self._device.id}
         if self._update_mask is not None:
             params['updateMask'] = self._update_mask
 
         body = {}
-        if self._id is not None:
-            body['id'] = self._id
-        if self._name is not None:
-            body['name'] = self._name
-        if self._log_level is not None:
-            body['logLevel'] = self._log_level
-        if self._gateway_config is not None:
-            body['gatewayConfig'] = self._gateway_config
-        if self._meta_data is not None:
-            body['metadata'] = self._meta_data
-        if self._blocked is not None:
-            body['blocked'] = self._blocked
-        if self._credentials is not None:
-            body['credentials'] = self._credentials
+        if self._device.log_level is not None:
+            body['logLevel'] = self._device.log_level
+        if self._device.gateway_config is not None:
+            body['gatewayConfig'] = self._device.gateway_config
+        if self._device.meta_data is not None:
+            body['metadata'] = self._device.meta_data
+        if self._device._blocked is not None:
+            body['blocked'] = self._device._blocked
+        if self._device.credentials is not None:
+            body['credentials'] = self._device.credentials
 
         return params, body
 

--- a/clearblade/cloud/iot_v1/devices.py
+++ b/clearblade/cloud/iot_v1/devices.py
@@ -1,7 +1,8 @@
-from .http_client import SyncClient, AsyncClient
 from .config_manager import ClearBladeConfigManager
-from .pagers import ListDevicesPager, ListDevicesAsyncPager
 from .device_types import *
+from .http_client import AsyncClient, SyncClient
+from .pagers import ListDevicesAsyncPager, ListDevicesPager
+
 
 class ClearBladeDeviceManager():
 
@@ -23,7 +24,7 @@ class ClearBladeDeviceManager():
 
         if request is None:
             request = SendCommandToDeviceRequest(name, binary_data, subfolder)
-        params = {'name':request.name,'method':'sendCommandToDevice'}
+        params = {'name':request.parent,'method':'sendCommandToDevice'}
         body = {'binaryData':request.binary_data.decode("utf-8")}
 
         return params,body
@@ -52,7 +53,7 @@ class ClearBladeDeviceManager():
         if request is None:
             request = ModifyCloudToDeviceConfigRequest(name=name,version_to_update=version_to_update, binary_data=binary_data)
 
-        params = {'name': request.name, 'method': 'modifyCloudToDeviceConfig'}
+        params = {'name': request.parent, 'method': 'modifyCloudToDeviceConfig'}
         body = {'binaryData': request.binary_data.decode("utf-8"), 'versionToUpdate':request.version_to_update}
 
         return params, body
@@ -80,10 +81,6 @@ class ClearBladeDeviceManager():
         device) -> str:
         """Returns a fully-qualified device string."""
         
-        # set the region name and registry name in config manager
-        self._config_manager.region_name = location
-        self._config_manager.registry_name = registry
-
         return "projects/{project}/locations/{location}/registries/{registry}/devices/{device}".format(
             project=project,
             location=location,
@@ -98,9 +95,6 @@ class ClearBladeDeviceManager():
         ) -> str:
         """Returns a fully-qualified registry string."""
 
-        self._config_manager.region_name = location
-        self._config_manager.registry_name = registry
-        
         return "projects/{project}/locations/{location}/registries/{registry}".format(
             project=project,
             location=location,
@@ -113,9 +107,13 @@ class ClearBladeDeviceManager():
                     name: str = None,
                     binary_data: bytes = None,
                     subfolder: str = None):
+        if not request.parent:
+            raise Exception('Device path must be supplied to the request object.')
+
+        clearblade_config = self._config_manager.regional_config(parent=request.parent)
 
         params, body = self._prepare_for_send_command(request, name, binary_data, subfolder)
-        sync_client = SyncClient(clearblade_config=self._config_manager.regional_config)
+        sync_client = SyncClient(clearblade_config=clearblade_config)
         return sync_client.post(api_name="cloudiot_devices", request_params=params, request_body=body)
 
     async def send_command_async(self,
@@ -124,17 +122,25 @@ class ClearBladeDeviceManager():
                                  binary_data: str = None,
                                  subfolder: str = None ):
 
+        if not request.parent:
+            raise Exception('Device path must be supplied to the request object.')
+
         params, body = self._prepare_for_send_command(request, name, binary_data, subfolder)
-        async_client = AsyncClient(clearblade_config=await self._config_manager.regional_config_async)
+        clearblade_config=await self._config_manager.regional_config_async(request.parent)
+        async_client = AsyncClient(clearblade_config=clearblade_config)
         return await async_client.post(api_name="cloudiot_devices",
                                        request_params=params,
                                        request_body=body)
 
-    def create(self, request: CreateDeviceRequest,
-                     parent: str = None,
-                     device: Device = None) -> Device:
+    def create(self, request: CreateDeviceRequest) -> Device:
         body = self._create_device_body(request.device)
-        sync_client = SyncClient(clearblade_config=self._config_manager.regional_config)
+
+        if not request.parent:
+            raise Exception('Parent must be supplied to the request object.')
+
+        clearblade_config = self._config_manager.regional_config(parent=request.parent)
+
+        sync_client = SyncClient(clearblade_config=clearblade_config)
         response = sync_client.post(api_name="cloudiot_devices",
                                     request_body=body)
 
@@ -142,61 +148,80 @@ class ClearBladeDeviceManager():
         # other wise return None
         if response.status_code == 200:
             return self._create_device_from_response(response.json())
-        return None
+        return response.json()
 
     async def create_async(self, request: CreateDeviceRequest,
                            parent: str = None,
                            device: Device = None) -> Device:
+        if not request.parent:
+            raise Exception('Parent must be supplied to the request object.')
 
         body = self._create_device_body(request.device)
-        async_client = AsyncClient(clearblade_config= await self._config_manager.regional_config_async)
+        clearblade_config = await self._config_manager.regional_config_async(request.parent)
+        async_client = AsyncClient(clearblade_config=clearblade_config)
         response = await async_client.post(api_name="cloudiot_devices", request_body=body)
 
         if response.status_code == 200:
             return self._create_device_from_response(response.json())
-        return None
+        return response.json()
 
     def modify_cloud_device_config(self,
                                    request: ModifyCloudToDeviceConfigRequest,
                                    name:str = None,
                                    version_to_update : int = None,
                                    binary_data: bytes = None):
+        if not request.parent:
+            raise Exception('Device path must be supplied to the request object.')
+
+        clearblade_config = self._config_manager.regional_config(parent=request.parent)
+
         params, body = self._prepare_modify_cloud_config_device(request=request, name=name,
                                                                 binary_data=binary_data,
                                                                 version_to_update=version_to_update)
-        sync_client = SyncClient(clearblade_config=self._config_manager.regional_config)
+        sync_client = SyncClient(clearblade_config=clearblade_config)
         response = sync_client.post(api_name="cloudiot_devices", request_params=params, request_body=body)
 
         if response.status_code == 200:
-            return self._create_device_config(response.json)
+            return self._create_device_config(response.json())
 
-        return None
+        return response.json()
 
     async def modify_cloud_device_config_async(self,
                                         request: ModifyCloudToDeviceConfigRequest,
                                         name:str = None,
                                         version_to_update : int = None,
                                         binary_data: bytes = None):
+        if not request.parent:
+            raise Exception('Device path must be supplied to the request object.')
+
+        
         params, body = self._prepare_modify_cloud_config_device(request=request, name=name,
                                                                 binary_data=binary_data,
                                                                 version_to_update=version_to_update)
-        async_client = AsyncClient(clearblade_config=await self._config_manager.regional_config_async)
+        
+        clearblade_config=await self._config_manager.regional_config_async(request.parent)
+        async_client = AsyncClient(clearblade_config=clearblade_config)
         response = await async_client.post(api_name="cloudiot_devices",
                                            request_params=params,
                                            request_body=body)
         if response.status_code == 200:
-            return self._create_device_config(response.json)
-        return None
+            return self._create_device_config(response.json())
+        return response
 
     def get_device_list_response(self, request:ListDevicesRequest):
-        sync_client = SyncClient(clearblade_config= self._config_manager.regional_config)
+        if not request.parent:
+            raise Exception('Registry path must be supplied to the request object.')
+
+        clearblade_config = self._config_manager.regional_config(parent=request.parent)
+
+        sync_client = SyncClient(clearblade_config=clearblade_config)
 
         params = request._prepare_params_for_list()
         response = sync_client.get(api_name="cloudiot_devices",request_params=params)
 
         if response.status_code == 200:
             return ListDevicesResponse.from_json(response.json())
-        return None
+        return response
 
     def list(self,
              request: ListDevicesRequest):
@@ -208,13 +233,18 @@ class ClearBladeDeviceManager():
         return None
 
     async def get_device_list_async(self, request: ListDevicesRequest):
+
+        if not request.parent:
+            raise Exception('Registry path must be supplied to the request object.')
+
         params = request._prepare_params_for_list()
-        async_client = AsyncClient(clearblade_config=await self._config_manager.regional_config_async)
+        clearblade_config=await self._config_manager.regional_config_async(request.parent)
+        async_client = AsyncClient(clearblade_config=clearblade_config)
         response = await async_client.get(api_name="cloudiot_devices",request_params=params)
 
         if response.status_code == 200:
             return ListDevicesResponse.from_json(response.json())
-        return None
+        return response
 
     async def list_async(self,
                          request: ListDevicesRequest):
@@ -227,80 +257,122 @@ class ClearBladeDeviceManager():
     def get(self,
             request: GetDeviceRequest) -> Device:
 
-        params = {'name':request.name}
-        sync_client = SyncClient(clearblade_config=self._config_manager.regional_config)
+        if not request.parent:
+            raise Exception('Device path must be supplied to the request object.')
+
+        clearblade_config = self._config_manager.regional_config(parent=request.parent)
+
+        params = {'name':request.parent}
+        sync_client = SyncClient(clearblade_config=clearblade_config)
         response = sync_client.get(api_name="cloudiot_devices", request_params=params)
 
         if response.status_code == 200:
             return self._create_device_from_response(response.json())
-        return None
+        return response
 
     async def get_async(self,
                         request: GetDeviceRequest) -> Device:
-        params = {'name':request.name}
-        async_client = AsyncClient(clearblade_config=await self._config_manager.regional_config_async)
+        if not request.parent:
+            raise Exception('Device path must be supplied to the request object.')
+        
+        params = {'name':request.parent}
+        clearblade_config = await self._config_manager.regional_config_async(request.parent)
+        async_client = AsyncClient(clearblade_config=clearblade_config)
         response = await async_client.get(api_name="cloudiot_devices", request_params=params)
 
         if response.status_code == 200:
             return self._create_device_from_response(response.json())
-        return None
+        
+        return response
 
     def delete(self,
                request: DeleteDeviceRequest):
-        params = {'name':request.name}
-        sync_client = SyncClient(clearblade_config=self._config_manager.regional_config)
+        if not request.parent:
+            raise Exception('Parent must be supplied to the request object.')
+
+        clearblade_config = self._config_manager.regional_config(parent=request.parent)
+
+        params = {'name':request.parent}
+        
+        sync_client = SyncClient(clearblade_config=clearblade_config)
         response = sync_client.delete(api_name="cloudiot_devices",request_params=params)
         return response
 
     async def delete_async(self,
                request: DeleteDeviceRequest):
-        params = {'name':request.name}
-        async_client = AsyncClient(clearblade_config=await self._config_manager.regional_config_async)
+
+        if not request.parent:
+            raise Exception('Device path must be supplied to the request object.')
+
+        params = {'name':request.parent}
+        clearblade_config = await self._config_manager.regional_config_async(request.parent)
+        async_client = AsyncClient(clearblade_config=clearblade_config)
         response = await async_client.delete(api_name="cloudiot_devices", request_params=params)
         return response
 
     def update(self,
                request: UpdateDeviceRequest) -> Device:
+        if not request.parent:
+            raise Exception('Device path must be supplied to the request object.')
+
+        clearblade_config = self._config_manager.regional_config(parent=request.parent)
+
         params, body = request._prepare_params_body_for_update()
-        sync_client = SyncClient(clearblade_config=self._config_manager.regional_config)
+        sync_client = SyncClient(clearblade_config=clearblade_config)
         response = sync_client.patch(api_name= "cloudiot_devices",request_body=body, request_params=params)
 
         if response.status_code == 200:
             return self._create_device_from_response(json_response=response.json())
-        return None
+        return response
 
     async def update_async(self,
                            request: UpdateDeviceRequest) -> Device:
-        async_client = AsyncClient(clearblade_config=await self._config_manager.regional_config_async)
+        if not request.parent:
+            raise Exception('Parent must be supplied to the request object.')
+
         params, body = request._prepare_params_body_for_update()
+        clearblade_config=await self._config_manager.regional_config_async(request.parent)
+        async_client = AsyncClient(clearblade_config=clearblade_config)
         response = await async_client.patch(api_name="cloudiot_devices",request_body=body, request_params=params)
 
         if response.status_code == 200:
             return self._create_device_from_response(json_response=response.json())
-        return None
+        return response
 
 
     def bindGatewayToDevice(self,
                             request: BindDeviceToGatewayRequest) :
-
         body = {'deviceId':request.deviceId, 'gatewayId':request.gatewayId}
         params = {'method':'bindDeviceToGateway'}
-        sync_client = SyncClient(clearblade_config= self._config_manager.regional_config)
+
+        if not request.parent:
+            raise Exception('Parent must be supplied to the request object.')
+
+        clearblade_config = self._config_manager.regional_config(parent=request.parent)
+        sync_client = SyncClient(clearblade_config=clearblade_config)
         response = sync_client.post(api_name="cloudiot", request_params=params, request_body=body)
 
         return response
 
     async def bindGatewayToDevice_async(self,
                                         request: BindDeviceToGatewayRequest) :
+        if not request.parent:
+            raise Exception('Parent must be supplied to the request object.')
+       
         body = {'deviceId':request.deviceId, 'gatewayId':request.gatewayId}
         params = {'method':'bindDeviceToGateway'}
-        async_client = AsyncClient(clearblade_config=await self._config_manager.regional_config_async)
+        clearblade_config = await self._config_manager.regional_config_async(request.parent)
+        async_client = AsyncClient(clearblade_config=clearblade_config)
         response = await async_client.post(api_name="cloudiot", request_params=params, request_body=body)
         return response
 
     def unbindGatewayFromDevice(self,
                                 request: UnbindDeviceFromGatewayRequest) :
-        sync_client = SyncClient(clearblade_config= self._config_manager.regional_config)
+        if not request.parent:
+            raise Exception('Parent must be supplied to the request object.')
+        
+        clearblade_config = self._config_manager.regional_config(request.parent)
+        sync_client = SyncClient(clearblade_config=clearblade_config)
         body = {'deviceId':request.deviceId, 'gatewayId':request.gatewayId}
         params = {'method':'unbindDeviceFromGateway'}
         response = sync_client.post(api_name="cloudiot", request_params=params, request_body=body)
@@ -308,48 +380,71 @@ class ClearBladeDeviceManager():
 
     async def unbindGatewayFromDevice_async(self,
                                             request: UnbindDeviceFromGatewayRequest) :
-        async_client = AsyncClient(clearblade_config=await self._config_manager.regional_config_async)
+        if not request.parent:
+            raise Exception('Parent must be supplied to the request object.')
+        
         body = {'deviceId':request.deviceId, 'gatewayId':request.gatewayId}
         params = {'method':'unbindDeviceFromGateway'}
+
+        clearblade_config = await self._config_manager.regional_config_async(request.parent)
+        async_client = AsyncClient(clearblade_config=clearblade_config)
         response = await async_client.post(api_name="cloudiot",request_params=params, request_body=body)
         return response
 
     def states_list(self,
                     request: ListDeviceStatesRequest):
-        params = {'name':request.name, 'numStates':request.num_states}
-        sync_client = SyncClient(clearblade_config=self._config_manager.regional_config)
+        if not request.parent:
+            raise Exception('Device Path must be supplied to the request object.')
+        
+        clearblade_config = self._config_manager.regional_config(request.parent)
+
+        params = {'name':request.parent, 'numStates':request.numStates}
+        sync_client = SyncClient(clearblade_config=clearblade_config)
         response = sync_client.get(api_name="cloudiot_devices_states",request_params=params)
 
         if response.status_code == 200:
             return ListDeviceStatesResponse.from_json(response.json())
-        return None
+        return response
 
     async def states_list_async(self,
                                        request: ListDeviceStatesRequest):
-        params = {'name':request.name, 'numStates':request.num_states}
-        async_client = AsyncClient(clearblade_config=self._config_manager.regional_config)
+
+        if not request.parent:
+            raise Exception('Device Path must be supplied to the request object.')
+        
+        params = {'name':request.parent, 'numStates':request.numStates}
+        clearblade_config=await self._config_manager.regional_config_async(request.parent)
+        async_client = AsyncClient(clearblade_config=clearblade_config)
         response = await async_client.get(api_name="cloudiot_devices_states", request_params=params)
 
         if response.status_code == 200:
             return ListDeviceStatesResponse.from_json(response.json())
-        return None
+        return response
 
     def config_versions_list(self,
                              request: ListDeviceConfigVersionsRequest):
-        params = {'name':request.name, 'numVersions':request.numVersions}
-        sync_client = SyncClient(clearblade_config=self._config_manager.regional_config)
+        if not request.parent:
+            raise Exception('Device Path must be supplied to the request object.')
+        
+        clearblade_config = self._config_manager.regional_config(request.parent)
+        params = {'name':request.parent, 'numVersions':request.numVersions}
+        sync_client = SyncClient(clearblade_config=clearblade_config)
         response = sync_client.get(api_name="cloudiot_devices_configVersions",request_params=params)
 
         if response.status_code == 200:
             return ListDeviceConfigVersionsResponse.from_json(response.json())
-        return None
+        return response
 
     async def config_versions_list_async(self,
-                                         request: ListDeviceConfigVersionsRequest):
-        params = {'name':request.name, 'numVersions':request.numVersions}
-        async_client = AsyncClient(clearblade_config= await self._config_manager.regional_config_async)
+                                         request: ListDeviceConfigVersionsRequest):     
+        if not request.parent:
+            raise Exception('Device Path must be supplied to the request object.')
+        
+        params = {'name':request.parent, 'numVersions':request.numVersions}
+        clearblade_config = await self._config_manager.regional_config_async(request.parent)
+        async_client = AsyncClient(clearblade_config=clearblade_config)
         response = await async_client.get(api_name="cloudiot_devices_configVersions", request_params=params)
 
         if response.status_code == 200:
             return ListDeviceConfigVersionsResponse.from_json(response.json())
-        return None
+        return response

--- a/clearblade/cloud/iot_v1/devices.py
+++ b/clearblade/cloud/iot_v1/devices.py
@@ -73,6 +73,41 @@ class ClearBladeDeviceManager():
         if 'registries' in data:
             self._config_manager.registry_name = data['registries']
 
+    def device_path(self,
+        project, 
+        location, 
+        registry, 
+        device) -> str:
+        """Returns a fully-qualified device string."""
+        
+        # set the region name and registry name in config manager
+        self._config_manager.region_name = location
+        self._config_manager.registry_name = registry
+
+        return "projects/{project}/locations/{location}/registries/{registry}/devices/{device}".format(
+            project=project,
+            location=location,
+            registry=registry,
+            device=device,
+        )
+
+    def registry_path(self,
+        project: str,
+        location: str,
+        registry: str,
+        ) -> str:
+        """Returns a fully-qualified registry string."""
+
+        self._config_manager.region_name = location
+        self._config_manager.registry_name = registry
+        
+        return "projects/{project}/locations/{location}/registries/{registry}".format(
+            project=project,
+            location=location,
+            registry=registry,
+        )
+
+
     def send_command(self,
                     request: SendCommandToDeviceRequest,
                     name: str = None,

--- a/clearblade/cloud/iot_v1/http_client.py
+++ b/clearblade/cloud/iot_v1/http_client.py
@@ -131,7 +131,7 @@ class AsyncClient(HttpClient):
 
     async def patch(self, api_name:str = None, request_params:dict = {}, request_body:dict = {}):
         super().patch(api_name = api_name, request_body=request_body)
-        return await self._async_client.patch("PATCH", url=self._post_url,
+        return await self._async_client.patch(url=self._post_url,
                                               headers=self._request_headers,
                                               params = request_params,
                                               data=self._post_body)

--- a/clearblade/cloud/iot_v1/registry.py
+++ b/clearblade/cloud/iot_v1/registry.py
@@ -1,7 +1,8 @@
-from .http_client import SyncClient, AsyncClient
 from .config_manager import ClearBladeConfigManager
+from .http_client import AsyncClient, SyncClient
+from .pagers import ListDeviceRegistriesAsyncPager, ListDeviceRegistryPager
 from .registry_types import *
-from .pagers import ListDeviceRegistryPager, ListDeviceRegistriesAsyncPager
+
 
 class ClearBladeRegistryManager():
     def __init__(self) -> None:
@@ -49,13 +50,23 @@ class ClearBladeRegistryManager():
 
     def get(self,
             request: GetDeviceRegistryRequest = None):
-        sync_client = SyncClient(clearblade_config=self._cb_config.regional_config)
+        if request.name == None:
+            raise Exception('Registry Path is not present in the request')
+
+        clearblade_config = self._cb_config.regional_config(request.name)
+
+        sync_client = SyncClient(clearblade_config=clearblade_config)
         response = sync_client.get(api_name = "cloudiot")
         return DeviceRegistry.from_json(response.json())
 
     async def get_async(self,
                         request: GetDeviceRegistryRequest = None):
-        async_client = AsyncClient(clearblade_config=await self._cb_config.regional_config_async)
+        
+        if request.name == None:
+            raise Exception('Registry Path is not present in the request')
+
+        clearblade_config=await self._cb_config.regional_config_async(request.name)
+        async_client = AsyncClient(clearblade_config=clearblade_config)
         response = await async_client.get(api_name = "cloudiot")
         return DeviceRegistry.from_json(response.json())
 
@@ -110,16 +121,26 @@ class ClearBladeRegistryManager():
 
     def patch(self,
         request: UpdateDeviceRegistryRequest = None)->DeviceRegistry:
+        if request.name == None:
+            raise Exception('Registry Path is not present in the request')
+
+        clearblade_config = self._cb_config.regional_config(request.name)
+        
         body = self._create_registry_body(request.device_registry)
         params = {'name':request.name, 'updateMask': request.update_mask}
-        sync_client = SyncClient(clearblade_config=self._cb_config.regional_config)
+        sync_client = SyncClient(clearblade_config=clearblade_config)
         response = sync_client.patch(api_name = "cloudiot",request_body=body,request_params=params)
         return DeviceRegistry.from_json(response.json())
 
     async def patch_async(self,
         request: UpdateDeviceRegistryRequest = None)->DeviceRegistry:
+        
+        if request.name == None:
+            raise Exception('Registry Path is not present in the request')
+
         body = self._create_registry_body(request.device_registry)
         params = {'name':request.name, 'updateMask': request.update_mask}
-        async_client = AsyncClient(clearblade_config=await self._cb_config.regional_config_async)
+        clearblade_config=await self._cb_config.regional_config_async(request.name)
+        async_client = AsyncClient(clearblade_config=clearblade_config)
         response = await async_client.patch(api_name = "cloudiot",request_body=body,request_params=params)
         return DeviceRegistry.from_json(response.json())

--- a/clearblade/cloud/iot_v1/utils.py
+++ b/clearblade/cloud/iot_v1/utils.py
@@ -1,18 +1,19 @@
 from typing import Any
 
+
 def find_project_region_registry_from_parent(parent):
     #projects/ingressdevelopmentenv/locations/us-central1/registries/gargi_python
     if not parent:
         return None
 
     list = parent.split("/")
-    project_region_registry_dict = {}
-    if "projects" in list and len(list) == 2:
-        project_region_registry_dict['projects'] = list[1]
-    if "locations" in list and len(list) == 4:
-        project_region_registry_dict['locations'] = list[3]
-    if "registries" in list and len(list) == 6:
-        project_region_registry_dict['registries'] = list[5]
+    project_region_registry_dict = {}    
+    if "projects" in list and len(list) >= 2:
+        project_region_registry_dict['project'] = list[1]
+    if "locations" in list and len(list) >= 4:
+        project_region_registry_dict['location'] = list[3]
+    if "registries" in list and len(list) >= 6:
+        project_region_registry_dict['registry'] = list[5]
 
     return project_region_registry_dict
 

--- a/samples/clearblade/bind_device_to_gateway.py
+++ b/samples/clearblade/bind_device_to_gateway.py
@@ -1,7 +1,24 @@
+import os
+
 from clearblade.cloud import iot_v1
+
 
 def sample_bind_device_to_gateway():
     client = iot_v1.DeviceManagerClient()
-    request = iot_v1.BindDeviceToGatewayRequest(deviceId='Python_101',gatewayId='gateway1')
+
+    parent = client.registry_path(
+        "api-project-320446546234", 
+        "us-central1", 
+        "rajas-test")
+
+    
+    request = iot_v1.BindDeviceToGatewayRequest(
+        parent=parent,
+        deviceId='test-dev-1',
+        gatewayId='smason_test_gateway'
+    )
     response = client.bind_device_to_gateway(request)
     print(response)
+
+os.environ["CLEARBLADE_CONFIGURATION"] = "/Users/rajas/Downloads/test-credentials.json"
+sample_bind_device_to_gateway()

--- a/samples/clearblade/bind_device_to_gateway_async.py
+++ b/samples/clearblade/bind_device_to_gateway_async.py
@@ -1,7 +1,24 @@
+import asyncio
+import os
+
 from clearblade.cloud import iot_v1
+
 
 async def sample_bind_device_to_gateway_async():
     async_client = iot_v1.DeviceManagerAsyncClient()
-    request = iot_v1.BindDeviceToGatewayRequest(deviceId='Python_101',gatewayId='gateway1')
+    
+    parent = async_client.registry_path(
+        "api-project-320446546234", 
+        "us-central1", 
+        "rajas-test")
+    
+    request = iot_v1.BindDeviceToGatewayRequest(
+        parent=parent,
+        deviceId='test-dev-1',
+        gatewayId='smason_test_gateway')
+    
     response = await async_client.bind_device_to_gateway(request)
     print(response)
+
+os.environ["CLEARBLADE_CONFIGURATION"] = "/Users/rajas/Downloads/test-credentials.json"
+asyncio.run(sample_bind_device_to_gateway_async())

--- a/samples/clearblade/create_device_async.py
+++ b/samples/clearblade/create_device_async.py
@@ -1,10 +1,23 @@
+import asyncio
+import os
+
 from clearblade.cloud import iot_v1
 
+
 async def sample_create_device_async():
-    client = iot_v1.DeviceManagerAsyncClient()
+    async_client = iot_v1.DeviceManagerAsyncClient()
+
+    parent = async_client.registry_path(
+        "api-project-320446546234", 
+        "us-central1", 
+        "deleteTest5")
 
     device = iot_v1.Device(id="Python_11", name="Python_11")
-    request = iot_v1.CreateDeviceRequest(device=device)
+    request = iot_v1.CreateDeviceRequest(parent=parent, device=device)
 
-    response = await client.create_device(request)
+    response = await async_client.create_device(request)
 
+    print(response)
+
+os.environ["CLEARBLADE_CONFIGURATION"] = "/Users/rajas/Downloads/test-credentials.json"
+asyncio.run(sample_create_device_async())

--- a/samples/clearblade/create_device_registry_async.py
+++ b/samples/clearblade/create_device_registry_async.py
@@ -1,3 +1,6 @@
+import asyncio
+import os
+
 from clearblade.cloud import iot_v1
 
 
@@ -14,7 +17,7 @@ async def sample_create_device_registry():
 
     # Initialize request argument(s)
     request = iot_v1.CreateDeviceRegistryRequest(
-        parent="projects/ingressdevelopmentenv/locations/us-central1",
+        parent="projects/api-project-320446546234/locations/us-central1",
         device_registry=registry
     )
 
@@ -23,3 +26,6 @@ async def sample_create_device_registry():
 
     # Handle the response
     print(response)
+
+os.environ["CLEARBLADE_CONFIGURATION"] = "/Users/rajas/Downloads/test-credentials.json"
+asyncio.run(sample_create_device_registry())

--- a/samples/clearblade/create_device_registry_sync.py
+++ b/samples/clearblade/create_device_registry_sync.py
@@ -1,26 +1,32 @@
+import os
+
 from clearblade.cloud import iot_v1
 
 
-def sample_create_device():
+def sample_create_device_registry():
     # Create a client
     client = iot_v1.DeviceManagerClient()
 
-    registry = iot_v1.DeviceRegistry(id='deleteTest5', name='deleteTest5',
-                                     mqttConfig={'mqttEnabledState':'MQTT_ENABLED'},
-                                     httpConfig={'httpEnabledState':'HTTP_ENABLED'},
-                                     logLevel='ERROR',
-                                     eventNotificationConfigs=[{'pubsubTopicName':'projects/ingressdevelopmentenv/topics/deleting'}]
-                                     )
+    registry = iot_v1.DeviceRegistry(
+        id='deleteTest5', 
+        name='deleteTest5',
+        mqttConfig={'mqttEnabledState':'MQTT_ENABLED'},
+        httpConfig={'httpEnabledState':'HTTP_ENABLED'},
+        logLevel='ERROR',
+        eventNotificationConfigs=[{'pubsubTopicName':'projects/api-project-320446546234/topics/deleting'}]
+    )
 
     # Initialize request argument(s)
     request = iot_v1.CreateDeviceRegistryRequest(
-        parent="projects/ingressdevelopmentenv/locations/us-central1",
+        parent="projects/api-project-320446546234/locations/us-central1",
         device_registry=registry
     )
 
     # Make the request
-    response = client.create_device(request=request)
+    response = client.create_device_registry(request=request)
 
     # Handle the response
     print(response)
 
+os.environ["CLEARBLADE_CONFIGURATION"] = "/Users/rajas/Downloads/test-credentials.json"
+sample_create_device_registry()

--- a/samples/clearblade/create_device_sync.py
+++ b/samples/clearblade/create_device_sync.py
@@ -1,11 +1,20 @@
+import os
+
 from clearblade.cloud import iot_v1
+
 
 def sample_create_device():
     client = iot_v1.DeviceManagerClient()
+    parent = client.registry_path(
+        "api-project-320446546234", 
+        "us-central1", 
+        "deleteTest5")
 
     device = iot_v1.Device(id="Python_11", name="Python_11")
-    request = iot_v1.CreateDeviceRequest(device=device)
+    request = iot_v1.CreateDeviceRequest(parent=parent, device=device)
 
     response = client.create_device(request)
+    print(response)
 
+os.environ["CLEARBLADE_CONFIGURATION"] = "/Users/rajas/Downloads/test-credentials.json"
 sample_create_device()

--- a/samples/clearblade/create_device_sync_es256.py
+++ b/samples/clearblade/create_device_sync_es256.py
@@ -1,0 +1,35 @@
+import io
+import os
+
+from clearblade.cloud import iot_v1
+
+
+def create_device_in_dev_iot(name, keyFile):
+    
+    client = iot_v1.DeviceManagerClient()
+
+    parent = client.registry_path(
+        "api-project-320446546234", 
+        "us-central1", 
+        "deleteTest5")
+
+    with io.open(keyFile) as f:
+        public_key = f.read()
+
+    device = iot_v1.Device(
+        id="my_test_device", 
+        name=name, 
+        credentials=[
+            {
+                "publicKey": {
+                    "format": "ES256_PEM",
+                    "key": public_key,
+                }
+            }])
+    
+    request = iot_v1.CreateDeviceRequest(parent=parent, device=device)
+    return client.create_device(request=request)
+
+device_name = "test_device"
+key_path = "../api-client/manager/resources/ec_public.pem"
+create_device_in_dev_iot(device_name, key_path)

--- a/samples/clearblade/create_device_sync_rs256.py
+++ b/samples/clearblade/create_device_sync_rs256.py
@@ -1,0 +1,36 @@
+import io
+import os
+
+from clearblade.cloud import iot_v1
+
+
+def create_device_in_dev_iot(name, keyFile):
+    
+    client = iot_v1.DeviceManagerClient()
+
+    parent = client.registry_path(
+        "api-project-320446546234", 
+        "us-central1", 
+        "deleteTest5")
+
+
+    with io.open(keyFile) as f:
+        public_key = f.read()
+
+    device = iot_v1.Device(
+        id="my_test_device", 
+        name=name, 
+        credentials=[
+            {
+                "publicKey": {
+                    "format": "RSA_PEM",
+                    "key": public_key,
+                }
+            }])
+    
+    request = iot_v1.CreateDeviceRequest(parent=parent, device=device)
+    return client.create_device(request=request)
+
+device_name = "test_device"
+key_path = "../api-client/manager/resources/rsa_cert.pem"
+create_device_in_dev_iot(device_name, key_path)

--- a/samples/clearblade/delete_device_async.py
+++ b/samples/clearblade/delete_device_async.py
@@ -1,8 +1,23 @@
+import asyncio
+import os
+
 from clearblade.cloud import iot_v1
+
 
 async def sample_device_delete_async():
     client = iot_v1.DeviceManagerAsyncClient()
-
-    request = iot_v1.DeleteDeviceRequest(name='Python_12')
+    
+    device_path = client.device_path(
+        "api-project-320446546234", 
+        "us-central1", 
+        "deleteTest5",
+        "Python_11")
+    
+    request = iot_v1.DeleteDeviceRequest(name=device_path)
 
     response = await client.delete_device(request)
+
+    print(response)
+
+os.environ["CLEARBLADE_CONFIGURATION"] = "/Users/rajas/Downloads/test-credentials.json"
+asyncio.run(sample_device_delete_async())

--- a/samples/clearblade/delete_device_registry_async.py
+++ b/samples/clearblade/delete_device_registry_async.py
@@ -1,3 +1,6 @@
+import asyncio
+import os
+
 from clearblade.cloud import iot_v1
 
 
@@ -5,10 +8,20 @@ async def sample_delete_device_registry():
     # Create a client
     client = iot_v1.DeviceManagerAsyncClient()
 
+    registry_path = client.registry_path(
+        "api-project-320446546234", 
+        "us-central1", 
+        "deleteTest5"
+    )
+
     # Initialize request argument(s)
     request = iot_v1.DeleteDeviceRegistryRequest(
-        name="projects/ingressdevelopmentenv/locations/us-central1/registries/deleteTest2"
+        name=registry_path
     )
 
     # Make the request
-    await client.delete_device_registry(request=request)
+    response = await client.delete_device_registry(request=request)
+    print(response)
+
+os.environ["CLEARBLADE_CONFIGURATION"] = "/Users/rajas/Downloads/test-credentials.json"
+asyncio.run(sample_delete_device_registry())

--- a/samples/clearblade/delete_device_registry_sync.py
+++ b/samples/clearblade/delete_device_registry_sync.py
@@ -1,3 +1,5 @@
+import os
+
 from clearblade.cloud import iot_v1
 
 
@@ -5,10 +7,20 @@ def sample_delete_device_registry():
     # Create a client
     client = iot_v1.DeviceManagerClient()
 
-    # Initialize request argument(s)
-    request = iot_v1.DeleteDeviceRegistryRequest(
-        name="projects/ingressdevelopmentenv/locations/us-central1/registries/deleteTest2",
+    registry_path = client.registry_path(
+        "api-project-320446546234", 
+        "us-central1", 
+        "deleteTest5"
     )
 
+    # Initialize request argument(s)
+    request = iot_v1.DeleteDeviceRegistryRequest(name=registry_path)
+
     # Make the request
-    client.delete_device_registry(request=request)
+    response = client.delete_device_registry(request=request)
+
+    print(response)
+
+os.environ["CLEARBLADE_CONFIGURATION"] = "/Users/rajas/Downloads/test-credentials.json"
+
+sample_delete_device_registry()

--- a/samples/clearblade/delete_device_sync.py
+++ b/samples/clearblade/delete_device_sync.py
@@ -1,7 +1,19 @@
+import os
+
 from clearblade.cloud import iot_v1
+
 
 def sample_device_delete():
     client = iot_v1.DeviceManagerClient()
-    request = iot_v1.DeleteDeviceRequest(name='Python_12')
+    device_path = client.device_path(
+        "api-project-320446546234", 
+        "us-central1", 
+        "deleteTest5",
+        "Python_11")
+    
+    request = iot_v1.DeleteDeviceRequest(name=device_path)
     response = client.delete_device(request)
     print(response)
+
+os.environ["CLEARBLADE_CONFIGURATION"] = "/Users/rajas/Downloads/test-credentials.json"
+sample_device_delete()

--- a/samples/clearblade/get_device_async.py
+++ b/samples/clearblade/get_device_async.py
@@ -1,8 +1,23 @@
+import asyncio
+import os
+
 from clearblade.cloud import iot_v1
+
 
 async def sample_device_get_async():
     client = iot_v1.DeviceManagerAsyncClient()
 
-    request = iot_v1.GetDeviceRequest(name='Python_12')
+    device_path = client.device_path(
+        "api-project-320446546234", 
+        "us-central1", 
+        "rajas-test",
+        "test-dev-1")  
+
+    request = iot_v1.GetDeviceRequest(name=device_path)
 
     response = await client.get_device(request)
+    
+    print(response.id)
+
+os.environ["CLEARBLADE_CONFIGURATION"] = "/Users/rajas/Downloads/test-credentials.json"
+asyncio.run(sample_device_get_async())

--- a/samples/clearblade/get_device_configversions_list_async.py
+++ b/samples/clearblade/get_device_configversions_list_async.py
@@ -1,9 +1,21 @@
+import asyncio
+import os
+
 from clearblade.cloud import iot_v1
+
 
 async def sample_get_device_config_versions_list_async():
     async_client = iot_v1.DeviceManagerAsyncClient()
 
-    request = iot_v1.ListDeviceConfigVersionsRequest(name='Rashmi_Device_Test', numVersions=3)
+    device_path = async_client.device_path(
+        "api-project-320446546234", 
+        "us-central1", 
+        "rajas-test",
+        "test-dev-1")  
+
+    request = iot_v1.ListDeviceConfigVersionsRequest(name=device_path, numVersions=3)
     response = await async_client.list_device_config_versions(request)
-    prin(response)
+    print(response.device_configs)
     
+os.environ["CLEARBLADE_CONFIGURATION"] = "/Users/rajas/Downloads/test-credentials.json"
+asyncio.run(sample_get_device_config_versions_list_async())

--- a/samples/clearblade/get_device_configversions_list_sync.py
+++ b/samples/clearblade/get_device_configversions_list_sync.py
@@ -1,9 +1,20 @@
+import os
+
 from clearblade.cloud import iot_v1
+
 
 def sample_get_device_config_versions_list():
     client = iot_v1.DeviceManagerClient()
 
-    request = iot_v1.ListDeviceConfigVersionsRequest(name='Rashmi_Device_Test', numVersions=3)
-    response = client.list_device_config_versions(request)
-    print(response)
+    device_path = client.device_path(
+        "api-project-320446546234", 
+        "us-central1", 
+        "rajas-test",
+        "test-dev-1")    
     
+    request = iot_v1.ListDeviceConfigVersionsRequest(name=device_path, numVersions=1)
+    response = client.list_device_config_versions(request)
+    print(response.device_configs)
+    
+os.environ["CLEARBLADE_CONFIGURATION"] = "/Users/rajas/Downloads/test-credentials.json"
+sample_get_device_config_versions_list()

--- a/samples/clearblade/get_device_registry_async.py
+++ b/samples/clearblade/get_device_registry_async.py
@@ -1,3 +1,6 @@
+import asyncio
+import os
+
 from clearblade.cloud import iot_v1
 
 
@@ -5,9 +8,14 @@ async def sample_get_device_registry():
     # Create a client
     client = iot_v1.DeviceManagerAsyncClient()
 
+    registry_path = client.registry_path(
+        "api-project-320446546234", 
+        "us-central1", 
+        "rajas-test")
+
     # Initialize request argument(s)
     request = iot_v1.GetDeviceRegistryRequest(
-        name="name_value",
+        name=registry_path,
     )
 
     # Make the request
@@ -15,3 +23,6 @@ async def sample_get_device_registry():
 
     # Handle the response
     print(response)
+
+os.environ["CLEARBLADE_CONFIGURATION"] = "/Users/rajas/Downloads/test-credentials.json"
+asyncio.run(sample_get_device_registry())

--- a/samples/clearblade/get_device_registry_sync.py
+++ b/samples/clearblade/get_device_registry_sync.py
@@ -1,3 +1,5 @@
+import os
+
 from clearblade.cloud import iot_v1
 
 
@@ -5,13 +7,21 @@ def sample_get_device_registry():
     # Create a client
     client = iot_v1.DeviceManagerClient()
 
+    registry_path = client.registry_path(
+        "api-project-320446546234", 
+        "us-central1", 
+        "rajas-test")
+
     # Initialize request argument(s)
     request = iot_v1.GetDeviceRegistryRequest(
-        name="name_value",
+        name=registry_path,
     )
 
     # Make the request
     response = client.get_device_registry(request=request)
 
     # Handle the response
-    print(response)
+    print(response.name)
+
+os.environ["CLEARBLADE_CONFIGURATION"] = "/Users/rajas/Downloads/test-credentials.json"
+sample_get_device_registry()

--- a/samples/clearblade/get_device_states_list_async.py
+++ b/samples/clearblade/get_device_states_list_async.py
@@ -1,8 +1,25 @@
+import asyncio
+import os
+
 from clearblade.cloud import iot_v1
+
 
 async def sample_get_device_states_list_async():
     async_client = iot_v1.DeviceManagerAsyncClient()
 
-    request = iot_v1.GetDeviceStatesList(name='Rashmi_Device_Test', numStates=3)
+    device_path = async_client.device_path(
+        "api-project-320446546234", 
+        "us-central1", 
+        "rajas-test",
+        "test-dev-1"
+    )
+
+
+    request = iot_v1.ListDeviceStatesRequest(name=device_path, numStates=3)
     response = await async_client.list_device_states(request)
+
+    print(response.device_states)
+
     
+os.environ["CLEARBLADE_CONFIGURATION"] = "/Users/rajas/Downloads/test-credentials.json"
+asyncio.run(sample_get_device_states_list_async())

--- a/samples/clearblade/get_device_states_list_sync.py
+++ b/samples/clearblade/get_device_states_list_sync.py
@@ -1,8 +1,21 @@
+import os
+
 from clearblade.cloud import iot_v1
+
 
 def sample_get_device_states_list():
     client = iot_v1.DeviceManagerClient()
+    device_path = client.device_path(
+        "api-project-320446546234", 
+        "us-central1", 
+        "rajas-test",
+        "test-dev-1"
+    )
 
-    request = iot_v1.GetDeviceStatesList(name='Rashmi_Device_Test', numStates=3)
+    request = iot_v1.ListDeviceStatesRequest(name=device_path, numStates=3)
     response = client.list_device_states(request)
+
+    print(response.device_states)
     
+os.environ["CLEARBLADE_CONFIGURATION"] = "/Users/rajas/Downloads/test-credentials.json"
+sample_get_device_states_list()

--- a/samples/clearblade/get_device_sync.py
+++ b/samples/clearblade/get_device_sync.py
@@ -1,8 +1,22 @@
+import os
+
 from clearblade.cloud import iot_v1
+
 
 def sample_device_get():
     client = iot_v1.DeviceManagerClient()
+    device_path = client.device_path(
+        "api-project-320446546234", 
+        "us-central1", 
+        "rajas-test",
+        "test-dev-1")  
 
-    request = iot_v1.GetDeviceRequest(name='Python_12')
+    request = iot_v1.GetDeviceRequest(name=device_path)
 
     response = client.get_device(request)
+
+    print(response.id)
+
+    
+os.environ["CLEARBLADE_CONFIGURATION"] = "/Users/rajas/Downloads/test-credentials.json"
+sample_device_get()

--- a/samples/clearblade/get_devices_list_async.py
+++ b/samples/clearblade/get_devices_list_async.py
@@ -1,10 +1,22 @@
+import asyncio
+import os
+
 from clearblade.cloud import iot_v1
+
 
 async def sample_get_devices_list_async():
     client = iot_v1.DeviceManagerAsyncClient()
 
-    request = iot_v1.ListDevicesRequest(parent='projects/ingressdevelopmentenv/locations/us-central1')
+    registry_path = client.registry_path(
+       "api-project-320446546234", 
+        "us-central1", 
+        "rajas-test")
 
-    response = await client.list_devices(request)
-    for page_result in response:
-        print(page_result)
+    request = iot_v1.ListDevicesRequest(parent=registry_path)
+
+    page_result = await client.list_devices(request)
+    async for response in page_result:
+        print(response) 
+
+os.environ["CLEARBLADE_CONFIGURATION"] = "/Users/rajas/Downloads/test-credentials.json"
+asyncio.run(sample_get_devices_list_async())

--- a/samples/clearblade/get_devices_list_sync.py
+++ b/samples/clearblade/get_devices_list_sync.py
@@ -1,9 +1,21 @@
+import os
+
 from clearblade.cloud import iot_v1
+
 
 def sample_get_devices_list():
     client = iot_v1.DeviceManagerClient()
 
-    request = iot_v1.ListDevicesRequest(parent='projects/ingressdevelopmentenv/locations/us-central1')
+    registry_path = client.registry_path(
+       "api-project-320446546234", 
+        "us-central1", 
+        "rajas-test")
+
+    request = iot_v1.ListDevicesRequest(parent=registry_path)
+    
     response = client.list_devices(request=request)
     for page_result in response:
         print(page_result)
+
+os.environ["CLEARBLADE_CONFIGURATION"] = "/Users/rajas/Downloads/test-credentials.json"
+sample_get_devices_list()

--- a/samples/clearblade/list_device_registries_async.py
+++ b/samples/clearblade/list_device_registries_async.py
@@ -1,4 +1,8 @@
+import asyncio
+import os
+
 from clearblade.cloud import iot_v1
+
 
 async def sample_list_device_registries():
     # Create a client
@@ -6,12 +10,15 @@ async def sample_list_device_registries():
 
     # Initialize request argument(s)
     request = iot_v1.ListDeviceRegistriesRequest(
-        parent="projects/ingressdevelopmentenv/locations/us-central1",
+        parent="projects/api-project-320446546234/locations/us-central1",
     )
 
     # Make the request
-    page_result = client.list_device_registries(request=request)
+    page_result = await client.list_device_registries(request=request)
 
     # Handle the response
     async for response in page_result:
         print(response)
+
+os.environ["CLEARBLADE_CONFIGURATION"] = "/Users/rajas/Downloads/test-credentials.json"
+asyncio.run(sample_list_device_registries())

--- a/samples/clearblade/list_device_registries_sync.py
+++ b/samples/clearblade/list_device_registries_sync.py
@@ -1,3 +1,5 @@
+import os
+
 from clearblade.cloud import iot_v1
 
 
@@ -7,7 +9,7 @@ def sample_list_device_registries():
 
     # Initialize request argument(s)
     request = iot_v1.ListDeviceRegistriesRequest(
-        parent="projects/ingressdevelopmentenv/locations/us-central1",
+        parent="projects/api-project-320446546234/locations/us-central1",
     )
 
     # Make the request
@@ -16,3 +18,6 @@ def sample_list_device_registries():
     # Handle the response
     for response in page_result:
         print(response)
+
+os.environ["CLEARBLADE_CONFIGURATION"] = "/Users/rajas/Downloads/test-credentials.json"
+sample_list_device_registries()

--- a/samples/clearblade/modify_cloud_to_device_config.py
+++ b/samples/clearblade/modify_cloud_to_device_config.py
@@ -1,7 +1,19 @@
+import os
+
 from clearblade.cloud import iot_v1
+
 
 def sample_modify_cloud_to_device_config():
     client = iot_v1.DeviceManagerClient()
-    modify_cloud_config_device_request = ModifyCloudToDeviceConfigRequest(name='python_1', binary_data=b'QUJD', version_to_update=1)
+    device_path = client.device_path(
+       "api-project-320446546234", 
+        "us-central1", 
+        "rajas-test",
+        "test-dev-1")
+
+    modify_cloud_config_device_request = iot_v1.ModifyCloudToDeviceConfigRequest(name=device_path, binary_data=b'aGVsbG8gcmFqYXMgd2Fzc3Vw', version_to_update=4)
     response = client.modify_cloud_to_device_config(request=modify_cloud_config_device_request)
     print(response)
+
+os.environ["CLEARBLADE_CONFIGURATION"] = "/Users/rajas/Downloads/test-credentials.json"
+sample_modify_cloud_to_device_config()

--- a/samples/clearblade/modify_cloud_to_device_config_async.py
+++ b/samples/clearblade/modify_cloud_to_device_config_async.py
@@ -1,7 +1,20 @@
+import asyncio
+import os
+
 from clearblade.cloud import iot_v1
+
 
 async def sample_modify_cloud_to_device_config_async():
     async_client = iot_v1.DeviceManagerAsyncClient()
-    modify_cloud_config_device_request = iot_v1.ModifyCloudToDeviceConfigRequest(name='python_1', binary_data=b'QUJD', version_to_update=1)
+    device_path = async_client.device_path(
+       "api-project-320446546234", 
+        "us-central1", 
+        "rajas-test",
+        "test-dev-1")
+   
+    modify_cloud_config_device_request = iot_v1.ModifyCloudToDeviceConfigRequest(name=device_path, binary_data=b'QUJD', version_to_update=6)
     response = await async_client.modify_cloud_to_device_config(request=modify_cloud_config_device_request)
     print(response)
+
+os.environ["CLEARBLADE_CONFIGURATION"] = "/Users/rajas/Downloads/test-credentials.json"
+asyncio.run(sample_modify_cloud_to_device_config_async())

--- a/samples/clearblade/send_command_to_device.py
+++ b/samples/clearblade/send_command_to_device.py
@@ -1,7 +1,20 @@
+import os
+
 from clearblade.cloud import iot_v1
+
 
 def sample_send_command_to_device():
     client = iot_v1.DeviceManagerClient()
-    request = iot_v1.SendCommandToDeviceRequest(name='python_1', binary_data=b"QUJD")
+    
+    device_path = client.device_path(
+        "api-project-320446546234", 
+        "us-central1", 
+        "rajas-test",
+        "test-dev-1")
+
+    request = iot_v1.SendCommandToDeviceRequest(name=device_path, binary_data=b"QUJD")
     response = client.send_command_to_device(request)
     print(response)
+
+os.environ["CLEARBLADE_CONFIGURATION"] = "/Users/rajas/Downloads/test-credentials.json"
+sample_send_command_to_device()

--- a/samples/clearblade/send_command_to_device_async.py
+++ b/samples/clearblade/send_command_to_device_async.py
@@ -1,7 +1,21 @@
+import asyncio
+import os
+
 from clearblade.cloud import iot_v1
+
 
 async def sample_send_command_to_device_async():
     async_client = iot_v1.DeviceManagerAsyncClient()
-    request = iot_v1.SendCommandToDeviceRequest(name='python_1', binary_data="QUJD")
+    
+    device_path = async_client.device_path(
+        "api-project-320446546234", 
+        "us-central1", 
+        "rajas-test",
+        "test-dev-1")
+    
+    request = iot_v1.SendCommandToDeviceRequest(name=device_path, binary_data=b"QUJD")
     response = await async_client.send_command_to_device(request)
     print(response)
+
+os.environ["CLEARBLADE_CONFIGURATION"] = "/Users/rajas/Downloads/test-credentials.json"
+asyncio.run(sample_send_command_to_device_async())

--- a/samples/clearblade/unbind_device_from_gateway.py
+++ b/samples/clearblade/unbind_device_from_gateway.py
@@ -1,7 +1,23 @@
+import os
+
 from clearblade.cloud import iot_v1
+
 
 def sample_unbind_device_from_gateway():
     client = iot_v1.DeviceManagerClient()
-    request = iot_v1.UnbindDeviceFromGatewayRequest(deviceId='Python_101',gatewayId='gateway1')
+    
+    parent =  client.registry_path(
+        "api-project-320446546234", 
+        "us-central1", 
+        "rajas-test")
+    
+    request = iot_v1.UnbindDeviceFromGatewayRequest(
+        parent=parent,
+        deviceId='test-dev-1',
+        gatewayId='smason_test_gateway'
+    )
     response = client.unbind_device_from_gateway(request)
     print(response)
+
+os.environ["CLEARBLADE_CONFIGURATION"] = "/Users/rajas/Downloads/test-credentials.json"
+sample_unbind_device_from_gateway()

--- a/samples/clearblade/unbind_device_from_gateway_async.py
+++ b/samples/clearblade/unbind_device_from_gateway_async.py
@@ -1,7 +1,25 @@
+import asyncio
+import os
+
 from clearblade.cloud import iot_v1
+
 
 async def sample_unbind_device_from_gateway_async():
     async_client = iot_v1.DeviceManagerAsyncClient()
-    request = iot_v1.UnbindDeviceFromGatewayRequest(deviceId='Python_101',gatewayId='gateway1')
+
+    parent = async_client.registry_path(
+        "api-project-320446546234", 
+        "us-central1", 
+        "rajas-test")
+
+    request = iot_v1.UnbindDeviceFromGatewayRequest(
+        parent=parent,
+        deviceId='test-dev-1',
+        gatewayId='smason_test_gateway'
+    )
+    
     response = await async_client.unbind_device_from_gateway(request)
     print(response)
+
+os.environ["CLEARBLADE_CONFIGURATION"] = "/Users/rajas/Downloads/test-credentials.json"
+asyncio.run(sample_unbind_device_from_gateway_async())

--- a/samples/clearblade/update_device_async.py
+++ b/samples/clearblade/update_device_async.py
@@ -1,8 +1,28 @@
+import asyncio
+import os
+
 from clearblade.cloud import iot_v1
+
 
 async def sample_update_device_async():
     client = iot_v1.DeviceManagerAsyncClient()
 
-    request = iot_v1.UpdateDeviceRequest(name='Rashmi_Device_Test',id='Rashmi_Device_Test',logLevel='NONE',blocked=True, updateMask='logLevel')
+    registry_path = client.registry_path(
+        "api-project-320446546234", 
+        "us-central1", 
+        "rajas-test")
+
+    device = iot_v1.Device(id="test-dev-1", blocked=True, log_level='NONE')
+    
+
+    request = iot_v1.UpdateDeviceRequest(
+        parent=registry_path,
+        device=device,
+        updateMask="logLevel,blocked")
 
     response = await client.update_device(request)
+
+    print(response)
+
+os.environ["CLEARBLADE_CONFIGURATION"] = "/Users/rajas/Downloads/test-credentials.json"
+asyncio.run(sample_update_device_async())

--- a/samples/clearblade/update_device_registry_async.py
+++ b/samples/clearblade/update_device_registry_async.py
@@ -1,3 +1,6 @@
+import asyncio
+import os
+
 from clearblade.cloud import iot_v1
 
 
@@ -10,13 +13,17 @@ async def sample_update_device_registry():
                                      mqttConfig={'mqttEnabledState':'MQTT_DISABLED'},
                                      logLevel='ERROR')
     # Initialize request argument(s)
-    request = iot_v1.UpdateDeviceRegistryRequest( name="projects/ingressdevelopmentenv/locations/us-central1/registries/deleteTest5",
-                                                  updateMask='mqttConfig.mqtt_enabled_state,logLevel',
-                                                  device_registry=registry
-                                                )
+    request = iot_v1.UpdateDeviceRegistryRequest( 
+        name="projects/api-project-320446546234/locations/us-central1/registries/deleteTest5",
+        updateMask='mqttConfig.mqtt_enabled_state,logLevel',
+        device_registry=registry
+    )
 
     # Make the request
     response = await client.update_device_registry(request=request)
 
     # Handle the response
     print(response)
+
+os.environ["CLEARBLADE_CONFIGURATION"] = "/Users/rajas/Downloads/test-credentials.json"
+asyncio.run(sample_update_device_registry())

--- a/samples/clearblade/update_device_registry_sync.py
+++ b/samples/clearblade/update_device_registry_sync.py
@@ -1,20 +1,30 @@
+import os
+
 from clearblade.cloud import iot_v1
 
 
 def sample_update_device_registry():
     # Create a client
     client = iot_v1.DeviceManagerClient()
-    registry = iot_v1.DeviceRegistry(id='deleteTest5', name='deleteTest5',
-                                     mqttConfig={'mqttEnabledState':'MQTT_DISABLED'},
-                                     logLevel='ERROR')
+    registry = iot_v1.DeviceRegistry(
+        id='deleteTest5', 
+        name='deleteTest5',
+        mqttConfig={'mqttEnabledState':'MQTT_DISABLED'},
+        logLevel='ERROR'
+    )
     # Initialize request argument(s)
-    request = iot_v1.UpdateDeviceRegistryRequest( name="projects/ingressdevelopmentenv/locations/us-central1/registries/deleteTest5",
-                                                  updateMask='mqttConfig.mqtt_enabled_state,logLevel',
-                                                  device_registry=registry
-                                                )
+    request = iot_v1.UpdateDeviceRegistryRequest( 
+        name="projects/api-project-320446546234/locations/us-central1/registries/deleteTest5",
+        updateMask='mqttConfig.mqtt_enabled_state,logLevel',
+        device_registry=registry
+    )
 
     # Make the request
     response = client.update_device_registry(request=request)
 
     # Handle the response
     print(response)
+
+os.environ["CLEARBLADE_CONFIGURATION"] = "/Users/rajas/Downloads/test-credentials.json"
+
+sample_update_device_registry()

--- a/samples/clearblade/update_device_sync.py
+++ b/samples/clearblade/update_device_sync.py
@@ -1,8 +1,27 @@
+import os
+
 from clearblade.cloud import iot_v1
+
 
 def sample_update_device():
     client = iot_v1.DeviceManagerClient()
+    
+    registry_path = client.registry_path(
+        "api-project-320446546234", 
+        "us-central1", 
+        "rajas-test")
+    
+    device = iot_v1.Device(id="test-dev-1", blocked=True, log_level='NONE')
 
-    request = iot_v1.UpdateDeviceRequest(name='Rashmi_Device_Test',id='Rashmi_Device_Test',logLevel='NONE',blocked=True, updateMask='logLevel')
+    request = iot_v1.UpdateDeviceRequest(
+        parent=registry_path,
+        device=device,
+        updateMask="logLevel"
+    )
 
     response = client.update_device(request)
+
+    print(response)
+
+os.environ["CLEARBLADE_CONFIGURATION"] = "/Users/rajas/Downloads/test-credentials.json"
+sample_update_device()

--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,8 @@ import os
 
 import setuptools
 
-name = "cleablade-cloud-iot"
-description = "Cloud IoT API API client library"
+name = "clearblade-cloud-iot"
+description = "Cloud IoT API client library"
 version = "1.0.0"
 release_status = "Development Status :: 5 - Production/Stable"
 dependencies = ["httpx"]


### PR DESCRIPTION
1. Removed the CLEARBLADE_REGION & CLEARBLADE_REGISTRY environment variables. 
2. Added device path and registry path methods at clients so that they can return qualified device and registry paths. 
3. Added exceptions if region and registry is not present before getting the tokens. 