### PR TITLE
Iot 918 conform to google format times binary data

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -103,8 +103,12 @@ Next Steps
 Note about types of times and binaryData
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- By default time parameters (e.g. **cloudUpdateTime**, **deviceAckTime**, **updateTime**) are returned as **RFC3339** strings (e.g. "2023-01-12T23:38:07.732Z").
-- To return times formatted as **DatetimeWithNanoseconds** (defined in the **proto.datetime_helpers** module) as returned by the **Google IoTCore Python SDK** set environment variable **TIME_FORMAT** to exactly **datetimewithnanoseconds**.
-- By default **CONFIG binaryData** is returned as a **base64-encoded string** and **STATE binaryData** is returned as a **NON-base64-encoded** string.
-- To return CONFIG and STATE binaryData as **BYTE ARRAYS** as returned by the Google IoTCore Python SDK, set environment variable **BINARYDATA_FORMAT** to exactly **bytes**.
-- If these environment variables are not set, or are set to any unexpeced values, then the default formats are returned.
+- By default the following parameters are returned as the shown types:
+1. All time parameters (e.g. **cloudUpdateTime**, **deviceAckTime**, **updateTime**): **RFC3339** strings (e.g. "2023-01-12T23:38:07.732Z")
+2. **CONFIG binaryData**: **base64-encoded string**
+3. **STATE binaryData**: **NON-base64-encoded string**.
+
+- To return these parameters using the same types used by the **Google IoTCore Python SDK**, set environment variable **BINARYDATA_AND_TIME_GOOGLE_FORMAT** to **True** (case-insensitive string). This will ensure the following parameters are returned as the shown types:
+1. All times: **DatetimeWithNanoseconds** (defined in the **proto.datetime_helpers** module)
+2. All **binaryData** (CONFIG, STATE etc.): **BYTE ARRAYS**
+- If this environment variable is not set, or is set to any unexpeced values, then the default types listed previously are used.

--- a/README.rst
+++ b/README.rst
@@ -106,7 +106,7 @@ Note about types of times and binaryData
 - By default the following parameters are returned as the shown types:
 1. All time parameters (e.g. **cloudUpdateTime**, **deviceAckTime**, **updateTime**): **RFC3339** strings (e.g. "2023-01-12T23:38:07.732Z")
 2. **CONFIG binaryData**: **base64-encoded string**
-3. **STATE binaryData**: **NON-base64-encoded string**.
+3. **STATE binaryData**: **NON-base64-encoded string**
 
 - To return these parameters using the same types used by the **Google IoTCore Python SDK**, set environment variable **BINARYDATA_AND_TIME_GOOGLE_FORMAT** to **True** (case-insensitive string). This will ensure the following parameters are returned as the shown types:
 1. All times: **DatetimeWithNanoseconds** (defined in the **proto.datetime_helpers** module)

--- a/README.rst
+++ b/README.rst
@@ -82,9 +82,10 @@ Next Steps
 Note about types of times and binaryData
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-By default time parameters (e.g. 'cloudUpdateTime', 'deviceAckTime', 'updateTime') are returned as RFC3339 strings (e.g. "2023-01-12T23:38:07.732Z").
-To return times formatted as 'DatetimeWithNanoseconds' (defined in the 'google.api_core.datetime_helpers' module) as per the Google IoTCore Python SDK, set environment variable TIME_FORMAT to exactly 'datetimewithnanoseconds'.
-If this environment variable is not set, or is set to any other value, then the default format is returned.
+- By default time parameters (e.g. **cloudUpdateTime**, **deviceAckTime**, **updateTime**) are returned as **RFC3339** strings (e.g. "2023-01-12T23:38:07.732Z").
+- To return times formatted as **DatetimeWithNanoseconds** (defined in the **google.api_core.datetime_helpers** module) as returned by the **Google IoTCore Python SDK**, set environment variable **TIME_FORMAT** to exactly **datetimewithnanoseconds**.
+- If this environment variable is not set, or is set to any other value, then the default format is returned.
 
-By default CONFIG binaryData is returned as a base64-encoded string and STATE binaryData is returned as a string (non-base64-encoded).
-To return CONFIG and STATE binaryData as BYTE ARRAYS (non-base64-encoded) as per the Google IoTCore Python SDK, set environment variable BINARYDATA_FORMAT to exactly 'bytes'. If this environment variable is not set, or is set to any other value, then the default formats are returned.
+- By default **CONFIG binaryData** is returned as a **base64-encoded string** and **STATE binaryData** is returned as a **NON-base64-encoded** string.
+- To return CONFIG and STATE binaryData as **BYTE ARRAYS** as returned by the Google IoTCore Python SDK, set environment variable **BINARYDATA_FORMAT** to exactly **bytes**.
+- If this environment variable is not set, or is set to any other value, then the default formats are returned.

--- a/README.rst
+++ b/README.rst
@@ -104,11 +104,15 @@ Note about types of times and binaryData
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - By default the following parameters are returned as the shown types:
+
 1. All time parameters (e.g. **cloudUpdateTime**, **deviceAckTime**, **updateTime**): **RFC3339** strings (e.g. "2023-01-12T23:38:07.732Z")
 2. **CONFIG binaryData**: **base64-encoded string**
 3. **STATE binaryData**: **NON-base64-encoded string**
 
+
 - To return these parameters using the same types used by the **Google IoTCore Python SDK**, set environment variable **BINARYDATA_AND_TIME_GOOGLE_FORMAT** to **True** (case-insensitive string). This will ensure the following parameters are returned as the shown types:
+
 1. All times: **DatetimeWithNanoseconds** (defined in the **proto.datetime_helpers** module)
 2. All **binaryData** (CONFIG, STATE etc.): **BYTE ARRAYS**
+
 - If this environment variable is not set, or is set to any unexpeced values, then the default types listed previously are used.

--- a/README.rst
+++ b/README.rst
@@ -84,8 +84,6 @@ Note about types of times and binaryData
 
 - By default time parameters (e.g. **cloudUpdateTime**, **deviceAckTime**, **updateTime**) are returned as **RFC3339** strings (e.g. "2023-01-12T23:38:07.732Z").
 - To return times formatted as **DatetimeWithNanoseconds** (defined in the **google.api_core.datetime_helpers** module) as returned by the **Google IoTCore Python SDK**, set environment variable **TIME_FORMAT** to exactly **datetimewithnanoseconds**.
-- If this environment variable is not set, or is set to any other value, then the default format is returned.
-
 - By default **CONFIG binaryData** is returned as a **base64-encoded string** and **STATE binaryData** is returned as a **NON-base64-encoded** string.
 - To return CONFIG and STATE binaryData as **BYTE ARRAYS** as returned by the Google IoTCore Python SDK, set environment variable **BINARYDATA_FORMAT** to exactly **bytes**.
-- If this environment variable is not set, or is set to any other value, then the default formats are returned.
+- If these environment variables are not set, or are set to any unexpeced values, then the default formats are returned.

--- a/README.rst
+++ b/README.rst
@@ -104,7 +104,10 @@ Note about types of times and binaryData
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - By default time parameters (e.g. **cloudUpdateTime**, **deviceAckTime**, **updateTime**) are returned as **RFC3339** strings (e.g. "2023-01-12T23:38:07.732Z").
-- To return times formatted as **DatetimeWithNanoseconds** (defined in the **google.api_core.datetime_helpers** module) as returned by the **Google IoTCore Python SDK**, set environment variable **TIME_FORMAT** to exactly **datetimewithnanoseconds**.
+- To return times formatted as **DatetimeWithNanoseconds** (defined in the **google.api_core.datetime_helpers** module) as returned by the **Google IoTCore Python SDK**:
+1. Run **pip install google-api-core** to install appropriate type.
+2. Set environment variable **TIME_FORMAT** to exactly **datetimewithnanoseconds**.
+
 - By default **CONFIG binaryData** is returned as a **base64-encoded string** and **STATE binaryData** is returned as a **NON-base64-encoded** string.
 - To return CONFIG and STATE binaryData as **BYTE ARRAYS** as returned by the Google IoTCore Python SDK, set environment variable **BINARYDATA_FORMAT** to exactly **bytes**.
 - If these environment variables are not set, or are set to any unexpeced values, then the default formats are returned.

--- a/README.rst
+++ b/README.rst
@@ -78,3 +78,13 @@ Next Steps
 - and execute the setup.py file like , python setup.py install.
 
 - mostly if you change you imports from from google.cloud to clearblade.cloud everything else should work.
+
+Note about types of times and binaryData
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+By default time parameters (e.g. 'cloudUpdateTime', 'deviceAckTime', 'updateTime') are returned as RFC3339 strings (e.g. "2023-01-12T23:38:07.732Z").
+To return times formatted as 'DatetimeWithNanoseconds' (defined in the 'google.api_core.datetime_helpers' module) as per the Google IoTCore Python SDK, set environment variable TIME_FORMAT to exactly 'datetimewithnanoseconds'.
+If this environment variable is not set, or is set to any other value, then the default format is returned.
+
+By default CONFIG binaryData is returned as a base64-encoded string and STATE binaryData is returned as a string (non-base64-encoded).
+To return CONFIG and STATE binaryData as BYTE ARRAYS (non-base64-encoded) as per the Google IoTCore Python SDK, set environment variable BINARYDATA_FORMAT to exactly 'bytes'. If this environment variable is not set, or is set to any other value, then the default formats are returned.

--- a/README.rst
+++ b/README.rst
@@ -104,10 +104,7 @@ Note about types of times and binaryData
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - By default time parameters (e.g. **cloudUpdateTime**, **deviceAckTime**, **updateTime**) are returned as **RFC3339** strings (e.g. "2023-01-12T23:38:07.732Z").
-- To return times formatted as **DatetimeWithNanoseconds** (defined in the **google.api_core.datetime_helpers** module) as returned by the **Google IoTCore Python SDK**:
-1. Run **pip install google-api-core** to install appropriate type.
-2. Set environment variable **TIME_FORMAT** to exactly **datetimewithnanoseconds**.
-
+- To return times formatted as **DatetimeWithNanoseconds** (defined in the **proto.datetime_helpers** module) as returned by the **Google IoTCore Python SDK** set environment variable **TIME_FORMAT** to exactly **datetimewithnanoseconds**.
 - By default **CONFIG binaryData** is returned as a **base64-encoded string** and **STATE binaryData** is returned as a **NON-base64-encoded** string.
 - To return CONFIG and STATE binaryData as **BYTE ARRAYS** as returned by the Google IoTCore Python SDK, set environment variable **BINARYDATA_FORMAT** to exactly **bytes**.
 - If these environment variables are not set, or are set to any unexpeced values, then the default formats are returned.

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,24 @@
+.. Copyright 2023 ClearBlade Inc.
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+        http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+    Copyright 2022 Google LLC
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+        http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+ 
 Python Client for ClearBlade Internet of Things (IoT) Core API
 ================================================================
 

--- a/README.rst
+++ b/README.rst
@@ -30,8 +30,9 @@ In order to use this library, you first need to go through the following steps:
 1. Install pip package - ```pip install clearblade-cloud-iot```
 
 
-2. Set an environment variable CLEARBLADE_CONFIGURATION which should point to your clearblade service account json file.
+2. Set an environment variable **CLEARBLADE_CONFIGURATION** which should point to your clearblade service account json file.
 
+3. Optionally set an environment variable **BINARYDATA_AND_TIME_GOOGLE_FORMAT** to True. Look at **Note about types of times and binaryData** below for details. 
 
 Installation
 ~~~~~~~~~~~~

--- a/clearblade/cloud/iot_v1/device_types.py
+++ b/clearblade/cloud/iot_v1/device_types.py
@@ -75,7 +75,7 @@ class Device():
         lastConfigSendTimeFromJson = get_value(json, 'lastConfigSendTime')
         lastErrorTimeFromJson = get_value(json, 'lastErrorTime')
         
-        convert_times_to_datetime_with_nanoseconds = (False if os.environ.get("TIME_FORMAT") == None else os.environ.get("TIME_FORMAT").lower() == "datetimewithnanoseconds")
+        convert_times_to_datetime_with_nanoseconds = (False if os.environ.get("BINARYDATA_AND_TIME_GOOGLE_FORMAT") == None else os.environ.get("BINARYDATA_AND_TIME_GOOGLE_FORMAT").lower() == "true")
         if convert_times_to_datetime_with_nanoseconds:
             last_heartbeat_time = None if lastHeartbeatTimeFromJson in [None, ""] else DatetimeWithNanoseconds.from_rfc3339(lastHeartbeatTimeFromJson)
             last_event_time = None if lastEventTimeFromJson in [None, ""] else DatetimeWithNanoseconds.from_rfc3339(lastEventTimeFromJson)
@@ -209,14 +209,14 @@ class DeviceState():
         updateTimeFromJson = get_value(response_json, 'updateTime')
         binaryDataFromJson = get_value(response_json, 'binaryData')
         
-        convert_times_to_datetime_with_nanoseconds = (False if os.environ.get("TIME_FORMAT") == None else os.environ.get("TIME_FORMAT").lower() == "datetimewithnanoseconds")
+        convert_times_to_datetime_with_nanoseconds = (False if os.environ.get("BINARYDATA_AND_TIME_GOOGLE_FORMAT") == None else os.environ.get("BINARYDATA_AND_TIME_GOOGLE_FORMAT").lower() == "true")
         if convert_times_to_datetime_with_nanoseconds:
             update_time = None if updateTimeFromJson in [None, ""] else DatetimeWithNanoseconds.from_rfc3339(updateTimeFromJson)
         else:
             update_time = updateTimeFromJson
 
         if (binaryDataFromJson not in [None, ""]):
-            convert_binarydata_to_bytes = (False if os.environ.get("BINARYDATA_FORMAT") == None else os.environ.get("BINARYDATA_FORMAT").lower() == "bytes")
+            convert_binarydata_to_bytes = (False if os.environ.get("BINARYDATA_AND_TIME_GOOGLE_FORMAT") == None else os.environ.get("BINARYDATA_AND_TIME_GOOGLE_FORMAT").lower() == "true")
             if convert_binarydata_to_bytes:
                 binary_data = binaryDataFromJson.encode('utf-8')
             else:
@@ -316,7 +316,7 @@ class DeviceConfig(Request):
         deviceAckTimeFromJson = get_value(json, 'deviceAckTime')
         binaryDataFromJson = get_value(json,'binaryData')
 
-        convert_times_to_datetime_with_nanoseconds = (False if os.environ.get("TIME_FORMAT") == None else os.environ.get("TIME_FORMAT").lower() == "datetimewithnanoseconds")
+        convert_times_to_datetime_with_nanoseconds = (False if os.environ.get("BINARYDATA_AND_TIME_GOOGLE_FORMAT") == None else os.environ.get("BINARYDATA_AND_TIME_GOOGLE_FORMAT").lower() == "true")
         if convert_times_to_datetime_with_nanoseconds:
             cloud_update_time = None if cloudUpdateTimeFromJson in [None, ""] else DatetimeWithNanoseconds.from_rfc3339(cloudUpdateTimeFromJson)
             device_ack_time = None if deviceAckTimeFromJson in [None, ""] else DatetimeWithNanoseconds.from_rfc3339(deviceAckTimeFromJson)
@@ -325,7 +325,7 @@ class DeviceConfig(Request):
             device_ack_time = deviceAckTimeFromJson
         
         if binaryDataFromJson not in [None, ""]:
-            convert_binarydata_to_bytes = (False if os.environ.get("BINARYDATA_FORMAT") == None else os.environ.get("BINARYDATA_FORMAT").lower() == "bytes")
+            convert_binarydata_to_bytes = (False if os.environ.get("BINARYDATA_AND_TIME_GOOGLE_FORMAT") == None else os.environ.get("BINARYDATA_AND_TIME_GOOGLE_FORMAT").lower() == "true")
             if convert_binarydata_to_bytes:
                 binary_data = base64.b64decode(binaryDataFromJson.encode('utf-8'))
             else:

--- a/clearblade/cloud/iot_v1/device_types.py
+++ b/clearblade/cloud/iot_v1/device_types.py
@@ -1,3 +1,32 @@
+# -*- coding: utf-8 -*-
+# Copyright 2023 ClearBlade Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 from typing import List
 from .resources import GatewayType, LogLevel
 from .utils import get_value

--- a/clearblade/cloud/iot_v1/device_types.py
+++ b/clearblade/cloud/iot_v1/device_types.py
@@ -31,7 +31,7 @@ from typing import List
 from .resources import GatewayType, LogLevel
 from .utils import get_value
 import os
-from google.api_core.datetime_helpers import DatetimeWithNanoseconds
+from proto.datetime_helpers import DatetimeWithNanoseconds
 import base64
 
 class Device():

--- a/clearblade/cloud/iot_v1/device_types.py
+++ b/clearblade/cloud/iot_v1/device_types.py
@@ -91,8 +91,6 @@ class Device():
             last_config_send_time = lastConfigSendTimeFromJson
             last_error_time = lastErrorTimeFromJson
 
-        convert_binarydata_to_bytes = (False if os.environ.get("BINARYDATA_FORMAT") == None else os.environ.get("BINARYDATA_FORMAT").lower() == "bytes")
-        
         deviceConfig = DeviceConfig.from_json(get_value(json, 'config'))
         config = { "version": deviceConfig.version, "cloudUpdateTime": deviceConfig.cloud_update_time }
         if (deviceConfig.binary_data not in [None, ""]):

--- a/clearblade/cloud/iot_v1/devices.py
+++ b/clearblade/cloud/iot_v1/devices.py
@@ -1,5 +1,3 @@
-import base64
-
 from .config_manager import ClearBladeConfigManager
 from .device_types import *
 from .http_client import AsyncClient, SyncClient

--- a/clearblade/cloud/iot_v1/devices.py
+++ b/clearblade/cloud/iot_v1/devices.py
@@ -1,3 +1,32 @@
+# -*- coding: utf-8 -*-
+# Copyright 2023 ClearBlade Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 from .config_manager import ClearBladeConfigManager
 from .device_types import *
 from .http_client import AsyncClient, SyncClient

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ name = "clearblade-cloud-iot"
 description = "Cloud IoT API client library"
 version = "1.0.5"
 release_status = "Development Status :: 5 - Production/Stable"
-dependencies = ["httpx"]
+dependencies = ["httpx", "proto.datetime_helpers"]
 
 package_root = os.path.abspath(os.path.dirname(__file__))
 

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ name = "clearblade-cloud-iot"
 description = "Cloud IoT API client library"
 version = "1.0.5"
 release_status = "Development Status :: 5 - Production/Stable"
-dependencies = ["httpx", "proto.datetime_helpers"]
+dependencies = ["httpx", "proto-plus"]
 
 package_root = os.path.abspath(os.path.dirname(__file__))
 


### PR DESCRIPTION
I have not created automated tests but I did run tests. If @ronak-ingress and/or @rajasd27 can run tests using the new env. vars. as per the README and using some devices you know have config and state. Running these functions in **samples/clearblade** would help:

get_device_async.py
get_device_configversions_list_async.py
get_device_states_list_async.py