### PR TITLE
'config', 'state' None? (i.e. not in fieldMask?)

### DIFF
--- a/clearblade/cloud/iot_v1/device_types.py
+++ b/clearblade/cloud/iot_v1/device_types.py
@@ -74,6 +74,8 @@ class Device():
         lastConfigAckTimeFromJson = get_value(json, 'lastConfigAckTime')
         lastConfigSendTimeFromJson = get_value(json, 'lastConfigSendTime')
         lastErrorTimeFromJson = get_value(json, 'lastErrorTime')
+        configFromJson = get_value(json, 'config')
+        stateFromJson = get_value(json, 'state')
         
         convert_times_to_datetime_with_nanoseconds = (False if os.environ.get("BINARYDATA_AND_TIME_GOOGLE_FORMAT") == None else os.environ.get("BINARYDATA_AND_TIME_GOOGLE_FORMAT").lower() == "true")
         if convert_times_to_datetime_with_nanoseconds:
@@ -91,15 +93,21 @@ class Device():
             last_config_send_time = lastConfigSendTimeFromJson
             last_error_time = lastErrorTimeFromJson
 
-        deviceConfig = DeviceConfig.from_json(get_value(json, 'config'))
-        config = { "version": deviceConfig.version, "cloudUpdateTime": deviceConfig.cloud_update_time }
-        if (deviceConfig.binary_data not in [None, ""]):
-            config["binaryData"] = deviceConfig.binary_data
-        if (deviceConfig.device_ack_time not in [None, ""]):
-            config["deviceAckTime"] = deviceConfig.device_ack_time
-
-        deviceState = DeviceState.from_json(get_value(json, 'state'))
-        state = { "updateTime": deviceState.update_time, "binaryData": deviceState.binary_data }
+        if (configFromJson):
+            deviceConfig = DeviceConfig.from_json(configFromJson)
+            config = { "version": deviceConfig.version, "cloudUpdateTime": deviceConfig.cloud_update_time }
+            if (deviceConfig.binary_data not in [None, ""]):
+                config["binaryData"] = deviceConfig.binary_data
+            if (deviceConfig.device_ack_time not in [None, ""]):
+                config["deviceAckTime"] = deviceConfig.device_ack_time
+        else:
+            config = configFromJson
+        
+        if (stateFromJson):
+            deviceState = DeviceState.from_json(stateFromJson)
+            state = { "updateTime": deviceState.update_time, "binaryData": deviceState.binary_data }
+        else:
+            state = stateFromJson
 
         return Device(
             id=get_value(json, 'id'),

--- a/clearblade/cloud/iot_v1/device_types.py
+++ b/clearblade/cloud/iot_v1/device_types.py
@@ -189,6 +189,26 @@ class Device():
         return self._last_heartbeat_time
     
     @property
+    def last_event_time(self):
+        return self._last_event_time
+    
+    @property
+    def last_state_time(self):
+        return self._last_state_time
+
+    @property
+    def last_config_ack_time(self):
+        return self._last_config_ack_time
+
+    @property
+    def last_config_send_time(self):
+        return self._last_config_send_time
+    
+    @property
+    def last_error_time(self):
+        return self._last_error_time
+
+    @property
     def blocked(self):
         return self._blocked
 


### PR DESCRIPTION
These checks for config and state being none are necessary in case fieldMask is set to exclude those. An error was being thrown in clearblade/cloud/iot_v1/utils.py line 20: "if key in json_data:" - json_data was None when this function was called for config and state.
