### PR TITLE
Iot 994 add credential classes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -128,5 +128,5 @@ Note about running from source instead of PyPi (pip) module:
 4. Precede that line with these (replace the path shown with the actual path on your machine. The path must end with "python-iot"):
 
 .. code-block:: console
-import sys
-sys.path.insert(0, "path/to/python-iot")
+    import sys
+    sys.path.insert(0, "path/to/python-iot")

--- a/README.rst
+++ b/README.rst
@@ -117,3 +117,15 @@ Note about types of times and binaryData
 2. All **binaryData** (CONFIG, STATE etc.): **BYTE ARRAYS**
 
 - If this environment variable is not set, or is set to any unexpeced values, then the default types listed previously are used.
+
+Note about running from source instead of PyPi (pip) module:
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+- To temporarily use the source code in this repo. instead of the installed PyPi (pip) module do the following:
+
+1. Clone this repo.
+2. Checkout the desired branch using **git checkout <branch>**.
+3. In your code find where **clearblade** or **clearblade.cloud** is being imported.
+4. Precede that line with these (replace the path shown with the actual path on your machine. The path must end with "python-iot"):
+
+import sys
+sys.path.insert(0, "path/to/python-iot")

--- a/README.rst
+++ b/README.rst
@@ -125,9 +125,11 @@ Note about running from source instead of PyPi (pip) module:
 1. Clone this repo.
 2. Checkout the desired branch using **git checkout <branch>**.
 3. In your code find where **clearblade** or **clearblade.cloud** is being imported.
-4. Precede that line with these (replace the path shown with the actual path on your machine. The path must end with "python-iot"):
+4. Precede that line with **import sys** and **sys.path.insert(0, <path_to_python-iot>)**. The path must end with "python-iot". So for example:
 
 .. code-block:: console
-    
+
     import sys
     sys.path.insert(0, "path/to/python-iot")
+
+    from clearblade.cloud import iot_v1

--- a/README.rst
+++ b/README.rst
@@ -128,5 +128,6 @@ Note about running from source instead of PyPi (pip) module:
 4. Precede that line with these (replace the path shown with the actual path on your machine. The path must end with "python-iot"):
 
 .. code-block:: console
+    
     import sys
     sys.path.insert(0, "path/to/python-iot")

--- a/README.rst
+++ b/README.rst
@@ -127,6 +127,6 @@ Note about running from source instead of PyPi (pip) module:
 3. In your code find where **clearblade** or **clearblade.cloud** is being imported.
 4. Precede that line with these (replace the path shown with the actual path on your machine. The path must end with "python-iot"):
 
+.. code-block:: console
 import sys
-
 sys.path.insert(0, "path/to/python-iot")

--- a/README.rst
+++ b/README.rst
@@ -128,4 +128,5 @@ Note about running from source instead of PyPi (pip) module:
 4. Precede that line with these (replace the path shown with the actual path on your machine. The path must end with "python-iot"):
 
 import sys
+
 sys.path.insert(0, "path/to/python-iot")

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -54,9 +54,8 @@ The version was made with the intent of minimizing required code changes. **Howe
 
 #
 
-#
-
 1. If **device** is an object of class **Device**.
+
    **Before**:
    device.credentials is of type **[dict]** (i.e. list of dicts).
 
@@ -80,9 +79,8 @@ The version was made with the intent of minimizing required code changes. **Howe
 
 #
 
-#
-
 2. This refers to pub_key mentioned in the previous section.
+
    **Before**:
    public_key was of type **dict**.
 
@@ -102,9 +100,8 @@ The version was made with the intent of minimizing required code changes. **Howe
 
 #
 
-#
+3. This section refers to **dev_config** which holds device config.
 
-3. This section refers to **dev_config** which holds device config...
    **Before**:
    dev_config is of type **dict**.
 
@@ -128,9 +125,8 @@ The version was made with the intent of minimizing required code changes. **Howe
 
 #
 
-#
+4. This section refers to **dev_state** which contains device state.
 
-4. This section refers to **dev_state** which contains device state...
    **Before**:
    dev_state is of type **dict**.
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -74,9 +74,9 @@ The version was made with the intent of minimizing required code changes. But so
    - **public_key = device.credentials[0].publicKey**
    - **public_key = device.credentials[0].public_key**
 
-   2. This refers to pub_key mentioned in the previous section.
-      **Before**:
-      public_key was of type **dict**.
+2. This refers to pub_key mentioned in the previous section.
+   **Before**:
+   public_key was of type **dict**.
 
    **After**:
    public_key is an object of class **PublicKeyCredential**.
@@ -92,9 +92,9 @@ The version was made with the intent of minimizing required code changes. But so
    - **format = public_key.get('format')**
    - **format = public_key.format**
 
-   3. This section refers to **dev_config** which holds device config...
-      **Before**:
-      dev_config is of type **dict**.
+3. This section refers to **dev_config** which holds device config...
+   **Before**:
+   dev_config is of type **dict**.
 
    **After**:
    dev_config is an object of class **DeviceConfig**.
@@ -114,9 +114,9 @@ The version was made with the intent of minimizing required code changes. But so
    - **cloud_update_time = device.credentials[0].cloudUpdateTime**
    - **cloud_update_time = device.credentials[0].cloud_update_time**
 
-   3. This section referst to **dev_state** which contains device state...
-      **Before**:
-      dev_state is of type **dict**.
+4. This section refers to **dev_state** which contains device state...
+   **Before**:
+   dev_state is of type **dict**.
 
    **After**:
    dev_state is an object of class **DeviceState**.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -67,12 +67,12 @@ The version was made with the intent of minimizing required code changes. But so
 
    e.g. All these are valid for retrieving the public key:
 
-   public_key = device.credentials[0]['publicKey']
-   public_key = device.credentials[0]['public_key']
-   public_key = device.credentials[0].get('publicKey')
-   public_key = device.credentials[0].get('public_key')
-   public_key = device.credentials[0].publicKey
-   public_key = device.credentials[0].public_key
+   - **public_key = device.credentials[0]['publicKey']**
+   - **public_key = device.credentials[0]['public_key']**
+   - **public_key = device.credentials[0].get('publicKey')**
+   - **public_key = device.credentials[0].get('public_key')**
+   - **public_key = device.credentials[0].publicKey**
+   - **public_key = device.credentials[0].public_key**
 
    2. This refers to pub_key mentioned in the previous section.
       **Before**:
@@ -88,9 +88,9 @@ The version was made with the intent of minimizing required code changes. But so
 
    e.g. All these are valid for retrieving the public key format:
 
-   format = public_key['format']
-   format = public_key.get('format')
-   format = public_key.format
+   - **format = public_key['format']**
+   - **format = public_key.get('format')**
+   - **format = public_key.format**
 
    3. This section refers to **dev_config** which holds device config...
       **Before**:
@@ -107,12 +107,12 @@ The version was made with the intent of minimizing required code changes. But so
 
    e.g. All these are valid for retrieving the cloud_update_time:
 
-   cloud_update_time = device.credentials[0]['cloudUpdateTime']
-   cloud_update_time = device.credentials[0]['cloud_update_time']
-   cloud_update_time = device.credentials[0].get('cloudUpdateTime')
-   cloud_update_time = device.credentials[0].get('cloud_update_time')
-   cloud_update_time = device.credentials[0].cloudUpdateTime
-   cloud_update_time = device.credentials[0].cloud_update_time
+   - **cloud_update_time = device.credentials[0]['cloudUpdateTime']**
+   - **cloud_update_time = device.credentials[0]['cloud_update_time']**
+   - **cloud_update_time = device.credentials[0].get('cloudUpdateTime')**
+   - **cloud_update_time = device.credentials[0].get('cloud_update_time')**
+   - **cloud_update_time = device.credentials[0].cloudUpdateTime**
+   - **cloud_update_time = device.credentials[0].cloud_update_time**
 
    3. This section referst to **dev_state** which contains device state...
       **Before**:
@@ -129,9 +129,9 @@ The version was made with the intent of minimizing required code changes. But so
 
    e.g. All these are valid for retrieving the binary_data:
 
-   binary_data = device.credentials[0]['binaryData']
-   binary_data = device.credentials[0]['binary_data']
-   binary_data = device.credentials[0].get('binaryData')
-   binary_data = device.credentials[0].get('binary_data')
-   binary_data = device.credentials[0].binaryData
-   binary_data = device.credentials[0].binary_data
+   - **binary_data = device.credentials[0]['binaryData']**
+   - **binary_data = device.credentials[0]['binary_data']**
+   - **binary_data = device.credentials[0].get('binaryData')**
+   - **binary_data = device.credentials[0].get('binary_data')**
+   - **binary_data = device.credentials[0].binaryData**
+   - **binary_data = device.credentials[0].binary_data**

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,44 +1,44 @@
-[//]: # "Copyright 2023 ClearBlade Inc."
+<!-- "Copyright 2023 ClearBlade Inc."
 
-[//]: # (Licensed under the Apache License, Version 2.0 (the "License");)
-[//]: # (you may not use this file except in compliance with the License.)
-[//]: # (You may obtain a copy of the License at)
-[//]: # (https://www.apache.org/licenses/LICENSE-2.0)
-[//]: # (Unless required by applicable law or agreed to in writing, software)
-[//]: # (distributed under the License is distributed on an "AS IS" BASIS,)
-[//]: # (WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.)
-[//]: # (See the License for the specific language governing permissions and)
-[//]: # (limitations under the License.)
-[//]: # (Copyright 2018 Google LLC)
-[//]: # (Licensed under the Apache License, Version 2.0 (the "License");)
-[//]: # (you may not use this file except in compliance with the License.)
-[//]: # (You may obtain a copy of the License at)
-[//]: # (https://www.apache.org/licenses/LICENSE-2.0)
-[//]: # (Unless required by applicable law or agreed to in writing, software)
-[//]: # (distributed under the License is distributed on an "AS IS" BASIS,)
-[//]: # (WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.)
-[//]: # (See the License for the specific language governing permissions and)
-[//]: # (limitations under the License.)
-[//]: # (Copyright 2023 ClearBlade Inc.)
-[//]: # (Licensed under the Apache License, Version 2.0 (the "License");)
-[//]: # (you may not use this file except in compliance with the License.)
-[//]: # (You may obtain a copy of the License at)
-[//]: # (https://www.apache.org/licenses/LICENSE-2.0)
-[//]: # (Unless required by applicable law or agreed to in writing, software)
-[//]: # (distributed under the License is distributed on an "AS IS" BASIS,)
-[//]: # (WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.)
-[//]: # (See the License for the specific language governing permissions and)
-[//]: # (limitations under the License.)
-[//]: # (Copyright 2018 Google LLC)
-[//]: # (Licensed under the Apache License, Version 2.0 (the "License");)
-[//]: # (you may not use this file except in compliance with the License.)
-[//]: # (You may obtain a copy of the License at)
-[//]: # (https://www.apache.org/licenses/LICENSE-2.0)
-[//]: # (Unless required by applicable law or agreed to in writing, software)
-[//]: # (distributed under the License is distributed on an "AS IS" BASIS,)
-[//]: # (WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.)
-[//]: # (See the License for the specific language governing permissions and)
-[//]: # (limitations under the License.)
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+Copyright 2018 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+Copyright 2023 ClearBlade Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+Copyright 2018 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. -->
 
 # 2.0.0 Migration Guide
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,43 +1,44 @@
-.. Copyright 2023 ClearBlade Inc.
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-https://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-Copyright 2018 Google LLC
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-https://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-Copyright 2023 ClearBlade Inc.
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-https://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-Copyright 2018 Google LLC
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-https://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+[//]: # "Copyright 2023 ClearBlade Inc."
+
+[//]: # (Licensed under the Apache License, Version 2.0 (the "License");)
+[//]: # (you may not use this file except in compliance with the License.)
+[//]: # (You may obtain a copy of the License at)
+[//]: # (https://www.apache.org/licenses/LICENSE-2.0)
+[//]: # (Unless required by applicable law or agreed to in writing, software)
+[//]: # (distributed under the License is distributed on an "AS IS" BASIS,)
+[//]: # (WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.)
+[//]: # (See the License for the specific language governing permissions and)
+[//]: # (limitations under the License.)
+[//]: # (Copyright 2018 Google LLC)
+[//]: # (Licensed under the Apache License, Version 2.0 (the "License");)
+[//]: # (you may not use this file except in compliance with the License.)
+[//]: # (You may obtain a copy of the License at)
+[//]: # (https://www.apache.org/licenses/LICENSE-2.0)
+[//]: # (Unless required by applicable law or agreed to in writing, software)
+[//]: # (distributed under the License is distributed on an "AS IS" BASIS,)
+[//]: # (WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.)
+[//]: # (See the License for the specific language governing permissions and)
+[//]: # (limitations under the License.)
+[//]: # (Copyright 2023 ClearBlade Inc.)
+[//]: # (Licensed under the Apache License, Version 2.0 (the "License");)
+[//]: # (you may not use this file except in compliance with the License.)
+[//]: # (You may obtain a copy of the License at)
+[//]: # (https://www.apache.org/licenses/LICENSE-2.0)
+[//]: # (Unless required by applicable law or agreed to in writing, software)
+[//]: # (distributed under the License is distributed on an "AS IS" BASIS,)
+[//]: # (WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.)
+[//]: # (See the License for the specific language governing permissions and)
+[//]: # (limitations under the License.)
+[//]: # (Copyright 2018 Google LLC)
+[//]: # (Licensed under the Apache License, Version 2.0 (the "License");)
+[//]: # (you may not use this file except in compliance with the License.)
+[//]: # (You may obtain a copy of the License at)
+[//]: # (https://www.apache.org/licenses/LICENSE-2.0)
+[//]: # (Unless required by applicable law or agreed to in writing, software)
+[//]: # (distributed under the License is distributed on an "AS IS" BASIS,)
+[//]: # (WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.)
+[//]: # (See the License for the specific language governing permissions and)
+[//]: # (limitations under the License.)
 
 # 2.0.0 Migration Guide
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -43,12 +43,14 @@ limitations under the License. -->
 # 2.0.0 Migration Guide
 
 The 2.0 release of the `clearblade-cloud-iot` client is a significant upgrade based on addition of two new classes in **iot_v1**:
-**DeviceCredential**
-**PublicKeyCredential**
+
+- **DeviceCredential**
+- **PublicKeyCredential**
 
 The release also includes enhancements to these classes already present in **iot_v1**:
-**DeviceConfig**
-**DeviceState**
+
+- **DeviceConfig**
+- **DeviceState**
 
 The version was made with the intent of minimizing required code changes. **However these changes should be considrered Breaking changes**.
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -50,9 +50,13 @@ The release also includes enhancements to these classes already present in **iot
 **DeviceConfig**
 **DeviceState**
 
-The version was made with the intent of minimizing required code changes. But some changes are Breaking.
+The version was made with the intent of minimizing required code changes. **However these changes should be considrered Breaking changes**.
 
-1. If **device** is an object of class **Device**...
+#
+
+#
+
+1. If **device** is an object of class **Device**.
    **Before**:
    device.credentials is of type **[dict]** (i.e. list of dicts).
 
@@ -74,6 +78,10 @@ The version was made with the intent of minimizing required code changes. But so
    - **public_key = device.credentials[0].publicKey**
    - **public_key = device.credentials[0].public_key**
 
+#
+
+#
+
 2. This refers to pub_key mentioned in the previous section.
    **Before**:
    public_key was of type **dict**.
@@ -91,6 +99,10 @@ The version was made with the intent of minimizing required code changes. But so
    - **format = public_key['format']**
    - **format = public_key.get('format')**
    - **format = public_key.format**
+
+#
+
+#
 
 3. This section refers to **dev_config** which holds device config...
    **Before**:
@@ -113,6 +125,10 @@ The version was made with the intent of minimizing required code changes. But so
    - **cloud_update_time = device.credentials[0].get('cloud_update_time')**
    - **cloud_update_time = device.credentials[0].cloudUpdateTime**
    - **cloud_update_time = device.credentials[0].cloud_update_time**
+
+#
+
+#
 
 4. This section refers to **dev_state** which contains device state...
    **Before**:

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,157 +1,136 @@
+.. Copyright 2023 ClearBlade Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+Copyright 2018 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+Copyright 2023 ClearBlade Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+Copyright 2018 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 # 2.0.0 Migration Guide
 
-The 2.0 release of the `google-cloud-iot` client is a significant upgrade based on a [next-gen code generator](https://github.com/googleapis/gapic-generator-python), and includes substantial interface changes. Existing code written for earlier versions of this library will likely require updates to use this version. This document describes the changes that have been made, and what you need to do to update your usage.
+The 2.0 release of the `clearblade-cloud-iot` client is a significant upgrade based on addition of two new classes in **iot_v1**:
+**DeviceCredential**
+**PublicKeyCredential**
 
-If you experience issues or have questions, please file an [issue](https://github.com/googleapis/python-iot/issues).
+The release also includes enhancements to these classes already present in **iot_v1**:
+**DeviceConfig**
+**DeviceState**
 
-## Supported Python Versions
+The version was made with the intent of minimizing required code changes. But some changes are Breaking.
 
-> **WARNING**: Breaking change
+1. If **device** is an object of class **Device**...
+   **Before**:
+   device.credentials is of type **[dict]** (i.e. list of dicts).
 
-The 2.0.0 release requires Python 3.6+.
+   **After**:
+   device.credentials is of type **[DeviceCredential]** (i.e. list of objects of class DeviceCredential).
 
+   The **DeviceCredential** class has these features for usability:
 
-## Method Calls
+   - A **get** method that mimics the **get** method of a dict.
+   - Allows accessing attributes using dot notation OR square-brackets.
+   - Supports camel-case as well as snake-case for accessing attributes:
 
-> **WARNING**: Breaking change
+   e.g. All these are valid for retrieving the public key:
 
-Methods expect request objects. We provide a script that will convert most common use cases.
+   public_key = device.credentials[0]['publicKey']
+   public_key = device.credentials[0]['public_key']
+   public_key = device.credentials[0].get('publicKey')
+   public_key = device.credentials[0].get('public_key')
+   public_key = device.credentials[0].publicKey
+   public_key = device.credentials[0].public_key
 
-* Install the library with `libcst`.
+   2. This refers to pub_key mentioned in the previous section.
+      **Before**:
+      public_key was of type **dict**.
 
-```py
-python3 -m pip install google-cloud-iot[libcst]
-```
+   **After**:
+   public_key is an object of class **PublicKeyCredential**.
 
-* The script `fixup_iot_v1_keywords.py` is shipped with the library. It expects
-an input directory (with the code to convert) and an empty destination directory.
+   The **PublicKeyCredential** class has these features for usability:
 
-```sh
-$ fixup_iot_v1_keywords.py --input-directory .samples/ --output-directory samples/
-```
+   - A **get** method that mimics the **get** method of a dict.
+   - Allows accessing attributes using dot notation OR square-brackets.
 
-**Before:**
-```py
-from google.cloud import iot_v1
+   e.g. All these are valid for retrieving the public key format:
 
-client = iot_v1.DeviceManagerClient()
+   format = public_key['format']
+   format = public_key.get('format')
+   format = public_key.format
 
-registry = client.get_device_registry("registry_name")
-```
+   3. This section refers to **dev_config** which holds device config...
+      **Before**:
+      dev_config is of type **dict**.
 
+   **After**:
+   dev_config is an object of class **DeviceConfig**.
 
-**After:**
-```py
-from google.cloud import iot_v1
+   The **DeviceConfig** class has these features for usability:
 
-client = iot_v1.DeviceManagerClient()
+   - A **get** method that mimics the **get** method of a dict.
+   - Allows accessing attributes using dot notation OR square-brackets.
+   - Supports camel-case as well as snake-case for accessing attributes:
 
-registry = client.get_device_registry(request={'name': "registry_name"})
-```
+   e.g. All these are valid for retrieving the cloud_update_time:
 
-### More Details
+   cloud_update_time = device.credentials[0]['cloudUpdateTime']
+   cloud_update_time = device.credentials[0]['cloud_update_time']
+   cloud_update_time = device.credentials[0].get('cloudUpdateTime')
+   cloud_update_time = device.credentials[0].get('cloud_update_time')
+   cloud_update_time = device.credentials[0].cloudUpdateTime
+   cloud_update_time = device.credentials[0].cloud_update_time
 
-In `google-cloud-iot<2.0.0`, parameters required by the API were positional parameters and optional parameters were keyword parameters.
+   3. This section referst to **dev_state** which contains device state...
+      **Before**:
+      dev_state is of type **dict**.
 
-**Before:**
-```py
-    def create_device(
-        self,
-        parent,
-        device,
-        retry=google.api_core.gapic_v1.method.DEFAULT,
-        timeout=google.api_core.gapic_v1.method.DEFAULT,
-        metadata=None,
-    ):
-```
+   **After**:
+   dev_state is an object of class **DeviceState**.
 
-In the 2.0.0 release, all methods have a single positional parameter `request`. Method docstrings indicate whether a parameter is required or optional.
+   The **DeviceState** class has these features for usability:
 
-Some methods have additional keyword only parameters. The available parameters depend on the `google.api.method_signature` annotation specified by the API producer.
+   - A **get** method that mimics the **get** method of a dict.
+   - Allows accessing attributes using dot notation OR square-brackets.
+   - Supports camel-case as well as snake-case for accessing attributes:
 
+   e.g. All these are valid for retrieving the binary_data:
 
-**After:**
-```py
-    def create_device(
-        self,
-        request: device_manager.CreateDeviceRequest = None,
-        *,
-        parent: str = None,
-        device: resources.Device = None,
-        retry: retries.Retry = gapic_v1.method.DEFAULT,
-        timeout: float = None,
-        metadata: Sequence[Tuple[str, str]] = (),
-    ) -> resources.Device:
-```
-
-> **NOTE:** The `request` parameter and flattened keyword parameters for the API are mutually exclusive.
-> Passing both will result in an error.
-
-
-Both of these calls are valid:
-
-```py
-response = client.create_device(
-    request={
-        "parent": parent,
-        "device": device,
-    }
-)
-```
-
-```py
-response = client.create_device(
-    parent=parent,
-    device=device,
-)
-```
-
-This call is invalid because it mixes `request` with a keyword argument `device`. Executing this code
-will result in an error.
-
-```py
-response = client.create_device(
-    request={
-        "parent": parent,
-    },
-    device=device
-)
-```
-
-
-
-## Enums and Types
-
-
-> **WARNING**: Breaking change
-
-The submodules `enums` and `types` have been removed.
-
-**Before:**
-```py
-from google.cloud import iot_v1
-
-gateway_type = iot_v1.enums.GatewayType.GATEWAY
-device = iot_v1.types.Device(name="name")
-```
-
-
-**After:**
-```py
-from google.cloud import iot_v1
-
-gateway_type = iot_v1.GatewayType.GATEWAY
-device = iot_v1.Device(name="name")
-```
-
-## Location Path Helper Method
-
-Location path helper method has been removed. Please construct
-the path manually.
-
-```py
-project = 'my-project'
-location = 'location'
-
-location_path = f'projects/{project}/locations/{location}'
-```
+   binary_data = device.credentials[0]['binaryData']
+   binary_data = device.credentials[0]['binary_data']
+   binary_data = device.credentials[0].get('binaryData')
+   binary_data = device.credentials[0].get('binary_data')
+   binary_data = device.credentials[0].binaryData
+   binary_data = device.credentials[0].binary_data

--- a/clearblade/cloud/iot_v1/__init__.py
+++ b/clearblade/cloud/iot_v1/__init__.py
@@ -1,3 +1,47 @@
+"""
+"Copyright 2023 ClearBlade Inc."
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+Copyright 2018 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+Copyright 2023 ClearBlade Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+Copyright 2018 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
 from .client import DeviceManagerClient, DeviceManagerAsyncClient
 from .device_types import *
 from .registry_types import *

--- a/clearblade/cloud/iot_v1/client.py
+++ b/clearblade/cloud/iot_v1/client.py
@@ -1,3 +1,47 @@
+"""
+"Copyright 2023 ClearBlade Inc."
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+Copyright 2018 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+Copyright 2023 ClearBlade Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+Copyright 2018 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
 from .device_types import *
 from .devices import *
 from .registry import *

--- a/clearblade/cloud/iot_v1/config.py
+++ b/clearblade/cloud/iot_v1/config.py
@@ -1,3 +1,47 @@
+"""
+"Copyright 2023 ClearBlade Inc."
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+Copyright 2018 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+Copyright 2023 ClearBlade Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+Copyright 2018 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
 class ClearBladeConfig:
     def __init__(self, system_key:str = None,
                  auth_token:str = None,

--- a/clearblade/cloud/iot_v1/config_manager.py
+++ b/clearblade/cloud/iot_v1/config_manager.py
@@ -1,3 +1,47 @@
+"""
+"Copyright 2023 ClearBlade Inc."
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+Copyright 2018 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+Copyright 2023 ClearBlade Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+Copyright 2018 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
 import json
 import os
 

--- a/clearblade/cloud/iot_v1/developer_tests.py
+++ b/clearblade/cloud/iot_v1/developer_tests.py
@@ -1,3 +1,47 @@
+"""
+"Copyright 2023 ClearBlade Inc."
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+Copyright 2018 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+Copyright 2023 ClearBlade Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+Copyright 2018 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
 from client import DeviceManagerClient, DeviceManagerAsyncClient
 from device_types import *
 from registry import *

--- a/clearblade/cloud/iot_v1/device_types.py
+++ b/clearblade/cloud/iot_v1/device_types.py
@@ -1,32 +1,47 @@
-# -*- coding: utf-8 -*-
-# Copyright 2023 ClearBlade Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-# Copyright 2022 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
+"""
+"Copyright 2023 ClearBlade Inc."
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+Copyright 2018 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+Copyright 2023 ClearBlade Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+Copyright 2018 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
 from typing import List
 from .resources import GatewayType, LogLevel, PublicKeyFormat, PublicKeyCredential, DeviceCredential
 from .utils import get_value

--- a/clearblade/cloud/iot_v1/device_types.py
+++ b/clearblade/cloud/iot_v1/device_types.py
@@ -35,9 +35,8 @@ from proto.datetime_helpers import DatetimeWithNanoseconds
 import base64
 
 def convertCredentialsFormatsFromString(credentials):
-    # Converts public Key Format from string to class PublicKeyFormat
+    # Converts public Key Format from string to object of class PublicKeyFormat
     for index, credential in enumerate(credentials):
-        credentialToReturn = {}
         if 'publicKey' in credential:
             credential['publicKey']['format'] = PublicKeyFormat(credential['publicKey']['format'])
             credentials[index] = DeviceCredential(credential)
@@ -502,7 +501,7 @@ class UpdateDeviceRequest(Request):
         if self._device._blocked is not None:
             body['blocked'] = self._device._blocked
         if self._device._credentials is not None:
-            body['credentials'] = self._device._credentials
+            body['credentials'] = DeviceCredential.convert_credentials_for_create_update(self._device._credentials)
 
         return params, body
 

--- a/clearblade/cloud/iot_v1/device_types.py
+++ b/clearblade/cloud/iot_v1/device_types.py
@@ -101,22 +101,6 @@ class Device():
             last_config_send_time = lastConfigSendTimeFromJson
             last_error_time = lastErrorTimeFromJson
 
-        if (configFromJson):
-            deviceConfig = DeviceConfig.from_json(configFromJson)
-            config = { "version": deviceConfig.version, "cloudUpdateTime": deviceConfig.cloud_update_time }
-            if (deviceConfig.binary_data not in [None, ""]):
-                config["binaryData"] = deviceConfig.binary_data
-            if (deviceConfig.device_ack_time not in [None, ""]):
-                config["deviceAckTime"] = deviceConfig.device_ack_time
-        else:
-            config = configFromJson
-        
-        if (stateFromJson):
-            deviceState = DeviceState.from_json(stateFromJson)
-            state = { "updateTime": deviceState.update_time, "binaryData": deviceState.binary_data }
-        else:
-            state = stateFromJson
-        
         return Device(
             id=get_value(json, 'id'),
             num_id=get_value(json, 'numId'),
@@ -129,8 +113,8 @@ class Device():
             last_error_time=last_error_time,
             blocked=get_value(json, 'blocked'),
             last_error_status_code=get_value(json, 'lastErrorStatus'),
-            config=config,
-            state=state,
+            config=DeviceConfig.from_json(configFromJson),
+            state=DeviceState.from_json(stateFromJson),
             log_level=get_value(json, 'logLevel'),
             meta_data=get_value(json, 'metadata'),
             gateway_config=get_value(json, 'gatewayConfig')
@@ -229,16 +213,22 @@ class Device():
 
 class DeviceState():
     def __init__(self, update_time: str = None, binary_data:str = None) -> None:
-        self._update_time = update_time
-        self._binary_data = binary_data
+        self.updateTime = update_time
+        self.binaryData = binary_data
+
+    def __getitem__(self, arg):
+        return getattr(self, arg)
+
+    def get(self, arg):
+        return getattr(self, arg)
 
     @property
     def update_time(self):
-        return self._update_time
+        return self.updateTime
 
     @property
     def binary_data(self):
-        return self._binary_data
+        return self.binaryData
 
     @staticmethod
     def from_json(response_json):
@@ -325,9 +315,15 @@ class DeviceConfig(Request):
                  binary_data) -> None:
         super().__init__(name)
         self._version = version
-        self._cloud_update_time = cloud_update_time
-        self._device_ack_time = device_ack_time
-        self._binary_data = binary_data
+        self.cloudUpdateTime = cloud_update_time
+        self.deviceAckTime = device_ack_time
+        self.binaryData = binary_data
+
+    def __getitem__(self, arg):
+        return getattr(self, arg)
+
+    def get(self, arg):
+        return getattr(self, arg)
 
     @property
     def version(self):
@@ -335,15 +331,15 @@ class DeviceConfig(Request):
 
     @property
     def cloud_update_time(self):
-        return self._cloud_update_time
+        return self.cloudUpdateTime
 
     @property
     def device_ack_time(self):
-        return self._device_ack_time
+        return self.deviceAckTime
 
     @property
     def binary_data(self):
-        return self._binary_data
+        return self.binaryData
 
     @staticmethod
     def from_json(json):

--- a/clearblade/cloud/iot_v1/devices.py
+++ b/clearblade/cloud/iot_v1/devices.py
@@ -60,6 +60,24 @@ class ClearBladeDeviceManager():
         return params,body
 
     def _create_device_body(self, device: Device) :
+
+        for index, credential in enumerate(device.credentials):
+            # Convert credential to dict if it is not
+            updateDeviceCredential = False
+            if (isinstance(credential, DeviceCredential)):
+                credential = credential.__dict__
+                updateDeviceCredential = True
+            
+            if 'publicKey' in credential:
+                if (isinstance(credential['publicKey'], PublicKeyCredential)):
+                    credential['publicKey'] = credential['publicKey'].__dict__
+                # Convert PublicKeyFormat to string
+                credential['publicKey']['format'] = PublicKeyFormat(credential['publicKey']['format']).value
+                updateDeviceCredential = True
+            
+            if updateDeviceCredential:
+                device.credentials[index] = credential
+            
         return {'id':device.id,
                 'credentials':device.credentials,
                 'config':device.config,

--- a/clearblade/cloud/iot_v1/devices.py
+++ b/clearblade/cloud/iot_v1/devices.py
@@ -1,32 +1,47 @@
-# -*- coding: utf-8 -*-
-# Copyright 2023 ClearBlade Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-# Copyright 2022 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
+"""
+"Copyright 2023 ClearBlade Inc."
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+Copyright 2018 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+Copyright 2023 ClearBlade Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+Copyright 2018 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
 from .config_manager import ClearBladeConfigManager
 from .device_types import *
 from .http_client import AsyncClient, SyncClient

--- a/clearblade/cloud/iot_v1/devices.py
+++ b/clearblade/cloud/iot_v1/devices.py
@@ -32,7 +32,7 @@ from .device_types import *
 from .http_client import AsyncClient, SyncClient
 from .pagers import ListDevicesAsyncPager, ListDevicesPager
 import base64
-
+from .resources import DeviceCredential
 
 class ClearBladeDeviceManager():
 
@@ -60,26 +60,8 @@ class ClearBladeDeviceManager():
         return params,body
 
     def _create_device_body(self, device: Device) :
-
-        for index, credential in enumerate(device.credentials):
-            # Convert credential to dict if it is not
-            updateDeviceCredential = False
-            if (isinstance(credential, DeviceCredential)):
-                credential = credential.__dict__
-                updateDeviceCredential = True
-            
-            if 'publicKey' in credential:
-                if (isinstance(credential['publicKey'], PublicKeyCredential)):
-                    credential['publicKey'] = credential['publicKey'].__dict__
-                # Convert PublicKeyFormat to string
-                credential['publicKey']['format'] = PublicKeyFormat(credential['publicKey']['format']).value
-                updateDeviceCredential = True
-            
-            if updateDeviceCredential:
-                device.credentials[index] = credential
-            
         return {'id':device.id,
-                'credentials':device.credentials,
+                'credentials':DeviceCredential.convert_credentials_for_create_update(device.credentials),
                 'config':device.config,
                 'blocked': device.blocked,
                 'logLevel':device.log_level, 'metadata':device.meta_data,

--- a/clearblade/cloud/iot_v1/http_client.py
+++ b/clearblade/cloud/iot_v1/http_client.py
@@ -1,3 +1,47 @@
+"""
+"Copyright 2023 ClearBlade Inc."
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+Copyright 2018 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+Copyright 2023 ClearBlade Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+Copyright 2018 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
 import json
 import httpx
 from .config import *

--- a/clearblade/cloud/iot_v1/pagers.py
+++ b/clearblade/cloud/iot_v1/pagers.py
@@ -1,3 +1,47 @@
+"""
+"Copyright 2023 ClearBlade Inc."
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+Copyright 2018 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+Copyright 2023 ClearBlade Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+Copyright 2018 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
 from .device_types import Device, ListDevicesResponse, ListDevicesRequest
 from .registry_types import DeviceRegistry, ListDeviceRegistriesRequest, ListDeviceRegistriesResponse
 from typing import Any, Awaitable, AsyncIterator, Callable

--- a/clearblade/cloud/iot_v1/registry.py
+++ b/clearblade/cloud/iot_v1/registry.py
@@ -1,3 +1,47 @@
+"""
+"Copyright 2023 ClearBlade Inc."
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+Copyright 2018 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+Copyright 2023 ClearBlade Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+Copyright 2018 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
 from .config_manager import ClearBladeConfigManager
 from .http_client import AsyncClient, SyncClient
 from .pagers import ListDeviceRegistriesAsyncPager, ListDeviceRegistryPager

--- a/clearblade/cloud/iot_v1/registry_types.py
+++ b/clearblade/cloud/iot_v1/registry_types.py
@@ -1,3 +1,47 @@
+"""
+"Copyright 2023 ClearBlade Inc."
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+Copyright 2018 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+Copyright 2023 ClearBlade Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+Copyright 2018 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
 from .utils import get_value
 from .resources import HttpState, MqttState, LogLevel
 

--- a/clearblade/cloud/iot_v1/resources.py
+++ b/clearblade/cloud/iot_v1/resources.py
@@ -1,3 +1,46 @@
+"""
+"Copyright 2023 ClearBlade Inc."
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+Copyright 2018 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+Copyright 2023 ClearBlade Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+Copyright 2018 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
 
 from enum import Enum
 from datetime import datetime

--- a/clearblade/cloud/iot_v1/resources.py
+++ b/clearblade/cloud/iot_v1/resources.py
@@ -162,7 +162,7 @@ class DeviceCredential():
             
             if 'expirationTime' in credential:
                 if (isinstance(credential['expirationTime'], datetime)):
-                    credential['expirationTime'] = credential['expirationTime'].isoformat()
+                    credential['expirationTime'] = credential['expirationTime'].strftime('%Y-%m-%dT%H:%M:%SZ')
                     updateDeviceCredential = True
     
             if updateDeviceCredential:

--- a/clearblade/cloud/iot_v1/resources.py
+++ b/clearblade/cloud/iot_v1/resources.py
@@ -67,9 +67,9 @@ class PublicKeyFormat(Enum):
     ES256_X509_PEM = "ES256_X509_PEM"
 
 class PublicKeyCredential():
-    def __init__(self, publicKeyFormat: PublicKeyFormat, publicKey: bytes):
-        self.format = publicKeyFormat
-        self.key = publicKey
+    def __init__(self, format: PublicKeyFormat, key: bytes):
+        self.format = format
+        self.key = key
     
     def __getitem__(self, arg):
         return getattr(self, arg)

--- a/clearblade/cloud/iot_v1/resources.py
+++ b/clearblade/cloud/iot_v1/resources.py
@@ -1,4 +1,6 @@
 
+from enum import Enum
+
 class MqttState():
     r"""Indicates whether an MQTT connection is enabled or disabled.
     See the field description for details.
@@ -56,7 +58,7 @@ class PublicKeyCertificateFormat():
     X509_CERTIFICATE_PEM = "X509_CERTIFICATE_PEM"
 
 
-class PublicKeyFormat:
+class PublicKeyFormat(Enum):
     r"""The supported formats for the public key."""
     UNSPECIFIED_PUBLIC_KEY_FORMAT = "UNSPECIFIED_PUBLIC_KEY_FORMAT"
     RSA_PEM = "RSA_PEM"

--- a/clearblade/cloud/iot_v1/resources.py
+++ b/clearblade/cloud/iot_v1/resources.py
@@ -65,3 +65,31 @@ class PublicKeyFormat(Enum):
     RSA_X509_PEM = "RSA_X509_PEM"
     ES256_PEM = "ES256_PEM"
     ES256_X509_PEM = "ES256_X509_PEM"
+
+class PublicKeyCredential():
+    def __init__(self, publicKeyFormat: PublicKeyFormat, publicKey: bytes):
+        self.format = publicKeyFormat
+        self.key = publicKey
+    
+    def __getitem__(self, arg):
+        return getattr(self, arg)
+
+
+class DeviceCredential():
+    def __init__(self, public_key, expiration_time=''):
+        if isinstance(public_key, dict):
+            self.publicKey = PublicKeyCredential(public_key['publicKey']['key'], public_key['publicKey']['format'])
+        else:
+            self.publicKey = public_key
+        self.expirationTime = expiration_time
+
+    def __getitem__(self, arg):
+        return getattr(self, arg)
+
+    @property
+    def public_key(self):
+        return self.publicKey
+
+    @property
+    def expiration_time(self):
+        return self.expirationTime

--- a/clearblade/cloud/iot_v1/resources.py
+++ b/clearblade/cloud/iot_v1/resources.py
@@ -1,5 +1,6 @@
 
 from enum import Enum
+from datetime import datetime
 
 class MqttState():
     r"""Indicates whether an MQTT connection is enabled or disabled.
@@ -116,6 +117,11 @@ class DeviceCredential():
                 credential['publicKey']['format'] = PublicKeyFormat(credential['publicKey']['format']).value
                 updateDeviceCredential = True
             
+            if 'expirationTime' in credential:
+                if (isinstance(credential['expirationTime'], datetime)):
+                    credential['expirationTime'] = credential['expirationTime'].isoformat()
+                    updateDeviceCredential = True
+    
             if updateDeviceCredential:
                 credentials[index] = credential
         

--- a/clearblade/cloud/iot_v1/resources.py
+++ b/clearblade/cloud/iot_v1/resources.py
@@ -74,6 +74,9 @@ class PublicKeyCredential():
     def __getitem__(self, arg):
         return getattr(self, arg)
 
+    def get(self, arg):
+        return getattr(self, arg)
+
 
 class DeviceCredential():
     def __init__(self, public_key, expiration_time=''):
@@ -84,6 +87,9 @@ class DeviceCredential():
         self.expirationTime = expiration_time
 
     def __getitem__(self, arg):
+        return getattr(self, arg)
+
+    def get(self, arg):
         return getattr(self, arg)
 
     @property

--- a/clearblade/cloud/iot_v1/resources.py
+++ b/clearblade/cloud/iot_v1/resources.py
@@ -78,7 +78,7 @@ class PublicKeyCredential():
 class DeviceCredential():
     def __init__(self, public_key, expiration_time=''):
         if isinstance(public_key, dict):
-            self.publicKey = PublicKeyCredential(public_key['publicKey']['key'], public_key['publicKey']['format'])
+            self.publicKey = PublicKeyCredential(public_key['publicKey']['format'], public_key['publicKey']['key'])
         else:
             self.publicKey = public_key
         self.expirationTime = expiration_time
@@ -93,3 +93,24 @@ class DeviceCredential():
     @property
     def expiration_time(self):
         return self.expirationTime
+
+    @classmethod
+    def convert_credentials_for_create_update(cls, credentials):
+        for index, credential in enumerate(credentials):
+            # Convert credential to dict if it is not
+            updateDeviceCredential = False
+            if (isinstance(credential, DeviceCredential)):
+                credential = credential.__dict__
+                updateDeviceCredential = True
+            
+            if 'publicKey' in credential:
+                if (isinstance(credential['publicKey'], PublicKeyCredential)):
+                    credential['publicKey'] = credential['publicKey'].__dict__
+                # Convert PublicKeyFormat to string
+                credential['publicKey']['format'] = PublicKeyFormat(credential['publicKey']['format']).value
+                updateDeviceCredential = True
+            
+            if updateDeviceCredential:
+                credentials[index] = credential
+        
+        return credentials

--- a/clearblade/cloud/iot_v1/utils.py
+++ b/clearblade/cloud/iot_v1/utils.py
@@ -1,3 +1,47 @@
+"""
+"Copyright 2023 ClearBlade Inc."
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+Copyright 2018 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+Copyright 2023 ClearBlade Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+Copyright 2018 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
 from typing import Any
 
 def find_project_region_registry_from_parent(parent):


### PR DESCRIPTION
The purpose of this PR is to allow access to attributes from device credentials and device public keys using dot-notation as well as square-bracket notation. It adds similar support for device states and device configs. And it allows for using camelCase as well as snake_case to access those attributes.

So all these work if 'credential' contains a public key:

keyInfo = credential.publicKey
keyInfo = credential.public_key
keyInfo = credential['publicKey']
keyInfo = credential['public_key']
keyInfo = credential.get('publicKey')
keyInfo - credential.get('public_key')

Look at UPGRADING.md for more details.