### PR TITLE
bug: def get_value; if json_data None throws err

### DIFF
--- a/clearblade/cloud/iot_v1/device_types.py
+++ b/clearblade/cloud/iot_v1/device_types.py
@@ -50,11 +50,12 @@ from proto.datetime_helpers import DatetimeWithNanoseconds
 import base64
 
 def convertCredentialsFormatsFromString(credentials):
-    # Converts public Key Format from string to object of class PublicKeyFormat
-    for index, credential in enumerate(credentials):
-        if 'publicKey' in credential:
-            credential['publicKey']['format'] = PublicKeyFormat(credential['publicKey']['format'])
-            credentials[index] = DeviceCredential(credential['publicKey'], credential['expirationTime'])
+    if credentials is not None:
+        # Converts public Key Format from string to object of class PublicKeyFormat
+        for index, credential in enumerate(credentials):
+            if 'publicKey' in credential:
+                credential['publicKey']['format'] = PublicKeyFormat(credential['publicKey']['format'])
+                credentials[index] = DeviceCredential(credential['publicKey'], credential['expirationTime'])
     return credentials
 
 class Device():

--- a/clearblade/cloud/iot_v1/utils.py
+++ b/clearblade/cloud/iot_v1/utils.py
@@ -61,8 +61,9 @@ def find_project_region_registry_from_parent(parent):
     return project_region_registry_dict
 
 def get_value(json_data, key):
-    if key in json_data:
-        return json_data[key]
+    if json_data is not None:
+        if key in json_data:
+            return json_data[key]
     return None
 
 class SingletonMetaClass(type):


### PR DESCRIPTION
When calling **iot_v1.DeviceManagerClient().list_devices(req)** where...

**req = iot_v1.ListDevicesRequest(parent=registry_path,fieldMask="...")**

...if the fieldMask string contained attributes whose values within a Device were None, then **def get_value(...)** in **utils.py** threw an unhandled error.

This PR corrects that bug.