### PR TITLE
Default log_level:  NONE-> LOG_LEVEL_UNSPECIFIED

### DIFF
--- a/clearblade/cloud/iot_v1/device_types.py
+++ b/clearblade/cloud/iot_v1/device_types.py
@@ -73,7 +73,9 @@ class Device():
                  last_error_time: str = None, last_error_status_code: dict = None,
                  config: dict = {"cloudUpdateTime":None, "version":""} ,
                  state: dict = {"updateTime":None, "binaryData":None},
-                 log_level: str = LogLevel.NONE, meta_data: dict = {}, gateway_config : dict = {"gatewayType": GatewayType.NON_GATEWAY}) -> None:
+                 log_level: str = LogLevel.LOG_LEVEL_UNSPECIFIED,
+                 meta_data: dict = {},
+                 gateway_config: dict = {"gatewayType": GatewayType.NON_GATEWAY}) -> None:
 
         self._id = id
         self._name = ''


### PR DESCRIPTION
@clarkbynum @ronak-ingress I tested before the change and a new device was indeed added with log_level NONE despite what the registry setting was.

With the change I saw the device was created with "Use system default settings" set:
![image](https://github.com/ClearBlade/python-iot/assets/13748001/54939eec-0dd6-4593-8c42-0fd9f4eb82f9)
 
